### PR TITLE
feat(error): add field context to DecodeError for better debugging

### DIFF
--- a/plugins/rust/benchmarks/src/benchmark_types.rs
+++ b/plugins/rust/benchmarks/src/benchmark_types.rs
@@ -500,22 +500,22 @@ impl<'buf> bebop::BebopDecode<'buf> for JsonValue<'buf> {
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
       1 => result::Result::Ok(Self::Null(
-        JsonNull::decode(reader).for_field("JsonValue", "null")?,
+        JsonNull::decode(reader).for_field("JsonValue", "Null")?,
       )),
       2 => result::Result::Ok(Self::Bool(
-        Bool::decode(reader).for_field("JsonValue", "bool")?,
+        Bool::decode(reader).for_field("JsonValue", "Bool")?,
       )),
       3 => result::Result::Ok(Self::Number(
-        Number::decode(reader).for_field("JsonValue", "number")?,
+        Number::decode(reader).for_field("JsonValue", "Number")?,
       )),
       4 => result::Result::Ok(Self::String(
-        String::decode(reader).for_field("JsonValue", "string")?,
+        String::decode(reader).for_field("JsonValue", "String")?,
       )),
       5 => result::Result::Ok(Self::List(
-        List::decode(reader).for_field("JsonValue", "list")?,
+        List::decode(reader).for_field("JsonValue", "List")?,
       )),
       6 => result::Result::Ok(Self::Object(
-        Object::decode(reader).for_field("JsonValue", "object")?,
+        Object::decode(reader).for_field("JsonValue", "Object")?,
       )),
       _ => result::Result::Err(bebop::DecodeError::InvalidUnion {
         type_name: "JsonValue",

--- a/plugins/rust/benchmarks/src/benchmark_types.rs
+++ b/plugins/rust/benchmarks/src/benchmark_types.rs
@@ -17,6 +17,7 @@ extern crate bebop_runtime;
 extern crate core;
 use alloc::{borrow, boxed, string, vec};
 use bebop_runtime as bebop;
+use bebop_runtime::DecodeContext as _;
 use core::convert::Into as _;
 use core::iter::{IntoIterator as _, Iterator as _};
 use core::{convert, default, iter, mem, ops, option, result};
@@ -86,10 +87,10 @@ impl<'buf> bebop::BebopDecode<'buf> for Person<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Person)
-    let id = reader.read_i32()?;
-    let name = borrow::Cow::Borrowed(reader.read_str()?);
-    let email = borrow::Cow::Borrowed(reader.read_str()?);
-    let age = reader.read_i32()?;
+    let id = reader.read_i32().for_field("Person", "id")?;
+    let name = borrow::Cow::Borrowed(reader.read_str().for_field("Person", "name")?);
+    let email = borrow::Cow::Borrowed(reader.read_str().for_field("Person", "email")?);
+    let age = reader.read_i32().for_field("Person", "age")?;
     // @@bebop_insertion_point(decode_end:Person)
     result::Result::Ok(Person {
       id,
@@ -179,12 +180,16 @@ impl<'buf> bebop::BebopDecode<'buf> for Order<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Order)
-    let order_id = reader.read_i64()?;
-    let customer_id = reader.read_i64()?;
-    let item_ids = reader.read_scalar_array::<i64>()?;
-    let quantities = reader.read_scalar_array::<i32>()?;
-    let total = reader.read_f64()?;
-    let timestamp = reader.read_i64()?;
+    let order_id = reader.read_i64().for_field("Order", "order_id")?;
+    let customer_id = reader.read_i64().for_field("Order", "customer_id")?;
+    let item_ids = reader
+      .read_scalar_array::<i64>()
+      .for_field("Order", "item_ids")?;
+    let quantities = reader
+      .read_scalar_array::<i32>()
+      .for_field("Order", "quantities")?;
+    let total = reader.read_f64().for_field("Order", "total")?;
+    let timestamp = reader.read_i64().for_field("Order", "timestamp")?;
     // @@bebop_insertion_point(decode_end:Order)
     result::Result::Ok(Order {
       order_id,
@@ -271,11 +276,12 @@ impl<'buf> bebop::BebopDecode<'buf> for Event<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Event)
-    let id = reader.read_i64()?;
-    let r#type = borrow::Cow::Borrowed(reader.read_str()?);
-    let source = borrow::Cow::Borrowed(reader.read_str()?);
-    let timestamp = reader.read_i64()?;
-    let payload = bebop::BebopBytes::borrowed(reader.read_byte_slice()?);
+    let id = reader.read_i64().for_field("Event", "id")?;
+    let r#type = borrow::Cow::Borrowed(reader.read_str().for_field("Event", "type")?);
+    let source = borrow::Cow::Borrowed(reader.read_str().for_field("Event", "source")?);
+    let timestamp = reader.read_i64().for_field("Event", "timestamp")?;
+    let payload =
+      bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field("Event", "payload")?);
     // @@bebop_insertion_point(decode_end:Event)
     result::Result::Ok(Event {
       id,
@@ -346,8 +352,14 @@ impl<'buf> bebop::BebopDecode<'buf> for TreeNode {
         break;
       }
       match tag {
-        1 => msg.value = option::Option::Some(reader.read_i32()?),
-        2 => msg.children = option::Option::Some(reader.read_array(|_r| TreeNode::decode(_r))?),
+        1 => msg.value = option::Option::Some(reader.read_i32().for_field("TreeNode", "value")?),
+        2 => {
+          msg.children = option::Option::Some(
+            reader
+              .read_array(|_r| TreeNode::decode(_r))
+              .for_field("TreeNode", "children")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "TreeNode",
@@ -487,12 +499,24 @@ impl<'buf> bebop::BebopDecode<'buf> for JsonValue<'buf> {
     let start = reader.position();
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
-      1 => result::Result::Ok(Self::Null(JsonNull::decode(reader)?)),
-      2 => result::Result::Ok(Self::Bool(Bool::decode(reader)?)),
-      3 => result::Result::Ok(Self::Number(Number::decode(reader)?)),
-      4 => result::Result::Ok(Self::String(String::decode(reader)?)),
-      5 => result::Result::Ok(Self::List(List::decode(reader)?)),
-      6 => result::Result::Ok(Self::Object(Object::decode(reader)?)),
+      1 => result::Result::Ok(Self::Null(
+        JsonNull::decode(reader).for_field("JsonValue", "null")?,
+      )),
+      2 => result::Result::Ok(Self::Bool(
+        Bool::decode(reader).for_field("JsonValue", "bool")?,
+      )),
+      3 => result::Result::Ok(Self::Number(
+        Number::decode(reader).for_field("JsonValue", "number")?,
+      )),
+      4 => result::Result::Ok(Self::String(
+        String::decode(reader).for_field("JsonValue", "string")?,
+      )),
+      5 => result::Result::Ok(Self::List(
+        List::decode(reader).for_field("JsonValue", "list")?,
+      )),
+      6 => result::Result::Ok(Self::Object(
+        Object::decode(reader).for_field("JsonValue", "object")?,
+      )),
       _ => result::Result::Err(bebop::DecodeError::InvalidUnion {
         type_name: "JsonValue",
         discriminator,
@@ -553,7 +577,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Bool {
         break;
       }
       match tag {
-        1 => msg.value = option::Option::Some(reader.read_bool()?),
+        1 => msg.value = option::Option::Some(reader.read_bool().for_field("Bool", "value")?),
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "Bool",
@@ -621,7 +645,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Number {
         break;
       }
       match tag {
-        1 => msg.value = option::Option::Some(reader.read_f64()?),
+        1 => msg.value = option::Option::Some(reader.read_f64().for_field("Number", "value")?),
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "Number",
@@ -699,7 +723,11 @@ impl<'buf> bebop::BebopDecode<'buf> for String<'buf> {
         break;
       }
       match tag {
-        1 => msg.value = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        1 => {
+          msg.value = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("String", "value")?,
+          ))
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "String",
@@ -780,7 +808,13 @@ impl<'buf> bebop::BebopDecode<'buf> for List<'buf> {
         break;
       }
       match tag {
-        1 => msg.values = option::Option::Some(reader.read_array(|_r| JsonValue::decode(_r))?),
+        1 => {
+          msg.values = option::Option::Some(
+            reader
+              .read_array(|_r| JsonValue::decode(_r))
+              .for_field("List", "values")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "List",
@@ -868,12 +902,16 @@ impl<'buf> bebop::BebopDecode<'buf> for Object<'buf> {
       }
       match tag {
         1 => {
-          msg.fields = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              JsonValue::decode(_r)?,
-            ))
-          })?)
+          msg.fields = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  JsonValue::decode(_r)?,
+                ))
+              })
+              .for_field("Object", "fields")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -982,15 +1020,27 @@ impl<'buf> bebop::BebopDecode<'buf> for Document<'buf> {
         break;
       }
       match tag {
-        1 => msg.title = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.body = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        1 => {
+          msg.title = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("Document", "title")?,
+          ))
+        }
+        2 => {
+          msg.body = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("Document", "body")?,
+          ))
+        }
         3 => {
-          msg.metadata = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              JsonValue::decode(_r)?,
-            ))
-          })?)
+          msg.metadata = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  JsonValue::decode(_r)?,
+                ))
+              })
+              .for_field("Document", "metadata")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -1117,9 +1167,9 @@ impl<'buf> bebop::BebopDecode<'buf> for TextSpan {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TextSpan)
-    let start = reader.read_u32()?;
-    let len = reader.read_u32()?;
-    let kind = ChunkKind::decode(reader)?;
+    let start = reader.read_u32().for_field("TextSpan", "start")?;
+    let len = reader.read_u32().for_field("TextSpan", "len")?;
+    let kind = ChunkKind::decode(reader).for_field("TextSpan", "kind")?;
     // @@bebop_insertion_point(decode_end:TextSpan)
     result::Result::Ok(TextSpan { start, len, kind })
   }
@@ -1177,8 +1227,10 @@ impl<'buf> bebop::BebopDecode<'buf> for ChunkedText<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:ChunkedText)
-    let source = borrow::Cow::Borrowed(reader.read_str()?);
-    let spans = reader.read_array(|_r| TextSpan::decode(_r))?;
+    let source = borrow::Cow::Borrowed(reader.read_str().for_field("ChunkedText", "source")?);
+    let spans = reader
+      .read_array(|_r| TextSpan::decode(_r))
+      .for_field("ChunkedText", "spans")?;
     // @@bebop_insertion_point(decode_end:ChunkedText)
     result::Result::Ok(ChunkedText { source, spans })
   }
@@ -1235,8 +1287,10 @@ impl<'buf> bebop::BebopDecode<'buf> for EmbeddingBf16<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:EmbeddingBf16)
-    let id = reader.read_uuid()?;
-    let vector = reader.read_scalar_array::<bebop::bf16>()?;
+    let id = reader.read_uuid().for_field("EmbeddingBf16", "id")?;
+    let vector = reader
+      .read_scalar_array::<bebop::bf16>()
+      .for_field("EmbeddingBf16", "vector")?;
     // @@bebop_insertion_point(decode_end:EmbeddingBf16)
     result::Result::Ok(EmbeddingBf16 { id, vector })
   }
@@ -1290,8 +1344,10 @@ impl<'buf> bebop::BebopDecode<'buf> for EmbeddingF32<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:EmbeddingF32)
-    let id = reader.read_uuid()?;
-    let vector = reader.read_scalar_array::<f32>()?;
+    let id = reader.read_uuid().for_field("EmbeddingF32", "id")?;
+    let vector = reader
+      .read_scalar_array::<f32>()
+      .for_field("EmbeddingF32", "vector")?;
     // @@bebop_insertion_point(decode_end:EmbeddingF32)
     result::Result::Ok(EmbeddingF32 { id, vector })
   }
@@ -1362,9 +1418,13 @@ impl<'buf> bebop::BebopDecode<'buf> for EmbeddingBatch<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:EmbeddingBatch)
-    let model = borrow::Cow::Borrowed(reader.read_str()?);
-    let embeddings = reader.read_array(|_r| EmbeddingBf16::decode(_r))?;
-    let usage_tokens = reader.read_u32()?;
+    let model = borrow::Cow::Borrowed(reader.read_str().for_field("EmbeddingBatch", "model")?);
+    let embeddings = reader
+      .read_array(|_r| EmbeddingBf16::decode(_r))
+      .for_field("EmbeddingBatch", "embeddings")?;
+    let usage_tokens = reader
+      .read_u32()
+      .for_field("EmbeddingBatch", "usage_tokens")?;
     // @@bebop_insertion_point(decode_end:EmbeddingBatch)
     result::Result::Ok(EmbeddingBatch {
       model,
@@ -1434,9 +1494,9 @@ impl<'buf> bebop::BebopDecode<'buf> for TokenLogprob<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TokenLogprob)
-    let token = borrow::Cow::Borrowed(reader.read_str()?);
-    let token_id = reader.read_u32()?;
-    let logprob = reader.read_f32()?;
+    let token = borrow::Cow::Borrowed(reader.read_str().for_field("TokenLogprob", "token")?);
+    let token_id = reader.read_u32().for_field("TokenLogprob", "token_id")?;
+    let logprob = reader.read_f32().for_field("TokenLogprob", "logprob")?;
     // @@bebop_insertion_point(decode_end:TokenLogprob)
     result::Result::Ok(TokenLogprob {
       token,
@@ -1494,7 +1554,9 @@ impl<'buf> bebop::BebopDecode<'buf> for TokenAlternatives<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TokenAlternatives)
-    let top_tokens = reader.read_array(|_r| TokenLogprob::decode(_r))?;
+    let top_tokens = reader
+      .read_array(|_r| TokenLogprob::decode(_r))
+      .for_field("TokenAlternatives", "top_tokens")?;
     // @@bebop_insertion_point(decode_end:TokenAlternatives)
     result::Result::Ok(TokenAlternatives { top_tokens })
   }
@@ -1577,11 +1639,18 @@ impl<'buf> bebop::BebopDecode<'buf> for LlmStreamChunk<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:LlmStreamChunk)
-    let chunk_id = reader.read_u32()?;
-    let tokens =
-      reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))?;
-    let logprobs = reader.read_array(|_r| TokenAlternatives::decode(_r))?;
-    let finish_reason = borrow::Cow::Borrowed(reader.read_str()?);
+    let chunk_id = reader.read_u32().for_field("LlmStreamChunk", "chunk_id")?;
+    let tokens = reader
+      .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
+      .for_field("LlmStreamChunk", "tokens")?;
+    let logprobs = reader
+      .read_array(|_r| TokenAlternatives::decode(_r))
+      .for_field("LlmStreamChunk", "logprobs")?;
+    let finish_reason = borrow::Cow::Borrowed(
+      reader
+        .read_str()
+        .for_field("LlmStreamChunk", "finish_reason")?,
+    );
     // @@bebop_insertion_point(decode_end:LlmStreamChunk)
     result::Result::Ok(LlmStreamChunk {
       chunk_id,
@@ -1673,12 +1742,18 @@ impl<'buf> bebop::BebopDecode<'buf> for TensorShard<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TensorShard)
-    let name = borrow::Cow::Borrowed(reader.read_str()?);
-    let shape = reader.read_scalar_array::<u32>()?;
-    let dtype = borrow::Cow::Borrowed(reader.read_str()?);
-    let data = reader.read_scalar_array::<bebop::bf16>()?;
-    let offset = reader.read_u64()?;
-    let total_elements = reader.read_u64()?;
+    let name = borrow::Cow::Borrowed(reader.read_str().for_field("TensorShard", "name")?);
+    let shape = reader
+      .read_scalar_array::<u32>()
+      .for_field("TensorShard", "shape")?;
+    let dtype = borrow::Cow::Borrowed(reader.read_str().for_field("TensorShard", "dtype")?);
+    let data = reader
+      .read_scalar_array::<bebop::bf16>()
+      .for_field("TensorShard", "data")?;
+    let offset = reader.read_u64().for_field("TensorShard", "offset")?;
+    let total_elements = reader
+      .read_u64()
+      .for_field("TensorShard", "total_elements")?;
     // @@bebop_insertion_point(decode_end:TensorShard)
     result::Result::Ok(TensorShard {
       name,
@@ -1740,9 +1815,15 @@ impl<'buf> bebop::BebopDecode<'buf> for InferenceTiming {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:InferenceTiming)
-    let queue_time = reader.read_duration()?;
-    let inference_time = reader.read_duration()?;
-    let tokens_per_second = reader.read_f32()?;
+    let queue_time = reader
+      .read_duration()
+      .for_field("InferenceTiming", "queue_time")?;
+    let inference_time = reader
+      .read_duration()
+      .for_field("InferenceTiming", "inference_time")?;
+    let tokens_per_second = reader
+      .read_f32()
+      .for_field("InferenceTiming", "tokens_per_second")?;
     // @@bebop_insertion_point(decode_end:InferenceTiming)
     result::Result::Ok(InferenceTiming {
       queue_time,
@@ -1816,9 +1897,13 @@ impl<'buf> bebop::BebopDecode<'buf> for InferenceResponse<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:InferenceResponse)
-    let request_id = reader.read_uuid()?;
-    let embeddings = reader.read_array(|_r| EmbeddingBf16::decode(_r))?;
-    let timing = InferenceTiming::decode(reader)?;
+    let request_id = reader
+      .read_uuid()
+      .for_field("InferenceResponse", "request_id")?;
+    let embeddings = reader
+      .read_array(|_r| EmbeddingBf16::decode(_r))
+      .for_field("InferenceResponse", "embeddings")?;
+    let timing = InferenceTiming::decode(reader).for_field("InferenceResponse", "timing")?;
     // @@bebop_insertion_point(decode_end:InferenceResponse)
     result::Result::Ok(InferenceResponse {
       request_id,

--- a/plugins/rust/benchmarks/src/benchmark_types.rs
+++ b/plugins/rust/benchmarks/src/benchmark_types.rs
@@ -43,12 +43,7 @@ impl<'buf> Person<'buf> {
   ) -> Self {
     let name = name.into();
     let email = email.into();
-    Self {
-      id,
-      name,
-      email,
-      age,
-    }
+    Self { id, name, email, age }
   }
 }
 
@@ -92,12 +87,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Person<'buf> {
     let email = borrow::Cow::Borrowed(reader.read_str().for_field("Person", "email")?);
     let age = reader.read_i32().for_field("Person", "age")?;
     // @@bebop_insertion_point(decode_end:Person)
-    result::Result::Ok(Person {
-      id,
-      name,
-      email,
-      age,
-    })
+    result::Result::Ok(Person { id, name, email, age })
   }
 }
 
@@ -128,14 +118,7 @@ impl<'buf> Order<'buf> {
   ) -> Self {
     let item_ids = item_ids.into();
     let quantities = quantities.into();
-    Self {
-      order_id,
-      customer_id,
-      item_ids,
-      quantities,
-      total,
-      timestamp,
-    }
+    Self { order_id, customer_id, item_ids, quantities, total, timestamp }
   }
 }
 
@@ -182,23 +165,12 @@ impl<'buf> bebop::BebopDecode<'buf> for Order<'buf> {
     // @@bebop_insertion_point(decode_start:Order)
     let order_id = reader.read_i64().for_field("Order", "order_id")?;
     let customer_id = reader.read_i64().for_field("Order", "customer_id")?;
-    let item_ids = reader
-      .read_scalar_array::<i64>()
-      .for_field("Order", "item_ids")?;
-    let quantities = reader
-      .read_scalar_array::<i32>()
-      .for_field("Order", "quantities")?;
+    let item_ids = reader.read_scalar_array::<i64>().for_field("Order", "item_ids")?;
+    let quantities = reader.read_scalar_array::<i32>().for_field("Order", "quantities")?;
     let total = reader.read_f64().for_field("Order", "total")?;
     let timestamp = reader.read_i64().for_field("Order", "timestamp")?;
     // @@bebop_insertion_point(decode_end:Order)
-    result::Result::Ok(Order {
-      order_id,
-      customer_id,
-      item_ids,
-      quantities,
-      total,
-      timestamp,
-    })
+    result::Result::Ok(Order { order_id, customer_id, item_ids, quantities, total, timestamp })
   }
 }
 
@@ -228,13 +200,7 @@ impl<'buf> Event<'buf> {
     let r#type = r#type.into();
     let source = source.into();
     let payload = payload.into();
-    Self {
-      id,
-      r#type,
-      source,
-      timestamp,
-      payload,
-    }
+    Self { id, r#type, source, timestamp, payload }
   }
 }
 
@@ -280,16 +246,9 @@ impl<'buf> bebop::BebopDecode<'buf> for Event<'buf> {
     let r#type = borrow::Cow::Borrowed(reader.read_str().for_field("Event", "type")?);
     let source = borrow::Cow::Borrowed(reader.read_str().for_field("Event", "source")?);
     let timestamp = reader.read_i64().for_field("Event", "timestamp")?;
-    let payload =
-      bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field("Event", "payload")?);
+    let payload = bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field("Event", "payload")?);
     // @@bebop_insertion_point(decode_end:Event)
-    result::Result::Ok(Event {
-      id,
-      r#type,
-      source,
-      timestamp,
-      payload,
-    })
+    result::Result::Ok(Event { id, r#type, source, timestamp, payload })
   }
 }
 
@@ -331,8 +290,7 @@ impl bebop::BebopEncode for TreeNode {
       size += bebop::wire_size::tagged_size(mem::size_of::<i32>());
     }
     if let option::Option::Some(ref v) = self.children {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -348,24 +306,11 @@ impl<'buf> bebop::BebopDecode<'buf> for TreeNode {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
         1 => msg.value = option::Option::Some(reader.read_i32().for_field("TreeNode", "value")?),
-        2 => {
-          msg.children = option::Option::Some(
-            reader
-              .read_array(|_r| TreeNode::decode(_r))
-              .for_field("TreeNode", "children")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "TreeNode",
-            tag,
-          });
-        }
+        2 => msg.children = option::Option::Some(reader.read_array(|_r| TreeNode::decode(_r)).for_field("TreeNode", "children")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "TreeNode", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:TreeNode)
@@ -386,7 +331,8 @@ impl TreeNode {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct JsonNull {}
+pub struct JsonNull {
+}
 
 impl JsonNull {
   pub fn new() -> Self {
@@ -449,45 +395,26 @@ impl<'buf> bebop::BebopEncode for JsonValue<'buf> {
     // @@bebop_insertion_point(encode_start:JsonValue)
     let pos = writer.reserve_message_length();
     match self {
-      Self::Null(inner) => {
-        writer.write_byte(1);
-        inner.encode(writer);
-      }
-      Self::Bool(inner) => {
-        writer.write_byte(2);
-        inner.encode(writer);
-      }
-      Self::Number(inner) => {
-        writer.write_byte(3);
-        inner.encode(writer);
-      }
-      Self::String(inner) => {
-        writer.write_byte(4);
-        inner.encode(writer);
-      }
-      Self::List(inner) => {
-        writer.write_byte(5);
-        inner.encode(writer);
-      }
-      Self::Object(inner) => {
-        writer.write_byte(6);
-        inner.encode(writer);
-      }
+      Self::Null(inner) => { writer.write_byte(1); inner.encode(writer); }
+      Self::Bool(inner) => { writer.write_byte(2); inner.encode(writer); }
+      Self::Number(inner) => { writer.write_byte(3); inner.encode(writer); }
+      Self::String(inner) => { writer.write_byte(4); inner.encode(writer); }
+      Self::List(inner) => { writer.write_byte(5); inner.encode(writer); }
+      Self::Object(inner) => { writer.write_byte(6); inner.encode(writer); }
     }
     writer.fill_message_length(pos);
     // @@bebop_insertion_point(encode_end:JsonValue)
   }
 
   fn encoded_size(&self) -> usize {
-    bebop::wire_size::WIRE_LEN_PREFIX_SIZE
-      + match self {
-        Self::Null(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::Bool(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::Number(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::String(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::List(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::Object(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-      }
+    bebop::wire_size::WIRE_LEN_PREFIX_SIZE + match self {
+      Self::Null(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::Bool(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::Number(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::String(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::List(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::Object(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+    }
   }
 }
 
@@ -499,28 +426,13 @@ impl<'buf> bebop::BebopDecode<'buf> for JsonValue<'buf> {
     let start = reader.position();
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
-      1 => result::Result::Ok(Self::Null(
-        JsonNull::decode(reader).for_field("JsonValue", "Null")?,
-      )),
-      2 => result::Result::Ok(Self::Bool(
-        Bool::decode(reader).for_field("JsonValue", "Bool")?,
-      )),
-      3 => result::Result::Ok(Self::Number(
-        Number::decode(reader).for_field("JsonValue", "Number")?,
-      )),
-      4 => result::Result::Ok(Self::String(
-        String::decode(reader).for_field("JsonValue", "String")?,
-      )),
-      5 => result::Result::Ok(Self::List(
-        List::decode(reader).for_field("JsonValue", "List")?,
-      )),
-      6 => result::Result::Ok(Self::Object(
-        Object::decode(reader).for_field("JsonValue", "Object")?,
-      )),
-      _ => result::Result::Err(bebop::DecodeError::InvalidUnion {
-        type_name: "JsonValue",
-        discriminator,
-      }),
+      1 => result::Result::Ok(Self::Null(JsonNull::decode(reader).for_field("JsonValue", "Null")?)),
+      2 => result::Result::Ok(Self::Bool(Bool::decode(reader).for_field("JsonValue", "Bool")?)),
+      3 => result::Result::Ok(Self::Number(Number::decode(reader).for_field("JsonValue", "Number")?)),
+      4 => result::Result::Ok(Self::String(String::decode(reader).for_field("JsonValue", "String")?)),
+      5 => result::Result::Ok(Self::List(List::decode(reader).for_field("JsonValue", "List")?)),
+      6 => result::Result::Ok(Self::Object(Object::decode(reader).for_field("JsonValue", "Object")?)),
+      _ => result::Result::Err(bebop::DecodeError::InvalidUnion { type_name: "JsonValue", discriminator }),
     };
     // @@bebop_insertion_point(decode_end:JsonValue)
     value
@@ -573,17 +485,10 @@ impl<'buf> bebop::BebopDecode<'buf> for Bool {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
         1 => msg.value = option::Option::Some(reader.read_bool().for_field("Bool", "value")?),
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "Bool",
-            tag,
-          });
-        }
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "Bool", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:Bool)
@@ -641,17 +546,10 @@ impl<'buf> bebop::BebopDecode<'buf> for Number {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
         1 => msg.value = option::Option::Some(reader.read_f64().for_field("Number", "value")?),
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "Number",
-            tag,
-          });
-        }
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "Number", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:Number)
@@ -719,21 +617,10 @@ impl<'buf> bebop::BebopDecode<'buf> for String<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.value = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("String", "value")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "String",
-            tag,
-          });
-        }
+        1 => msg.value = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("String", "value")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "String", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:String)
@@ -759,9 +646,7 @@ pub type ListOwned = List<'static>;
 impl<'buf> List<'buf> {
   pub fn into_owned(self) -> ListOwned {
     List {
-      values: self
-        .values
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      values: self.values.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -787,8 +672,7 @@ impl<'buf> bebop::BebopEncode for List<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.values {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -804,23 +688,10 @@ impl<'buf> bebop::BebopDecode<'buf> for List<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.values = option::Option::Some(
-            reader
-              .read_array(|_r| JsonValue::decode(_r))
-              .for_field("List", "values")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "List",
-            tag,
-          });
-        }
+        1 => msg.values = option::Option::Some(reader.read_array(|_r| JsonValue::decode(_r)).for_field("List", "values")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "List", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:List)
@@ -846,11 +717,7 @@ pub type ObjectOwned = Object<'static>;
 impl<'buf> Object<'buf> {
   pub fn into_owned(self) -> ObjectOwned {
     Object {
-      fields: self.fields.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned()))
-          .collect()
-      }),
+      fields: self.fields.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned())).collect()),
     }
   }
 }
@@ -866,10 +733,7 @@ impl<'buf> bebop::BebopEncode for Object<'buf> {
     // normally. This behavior should be revisited once the spec intent is clarified.
     if let option::Option::Some(ref v) = self.fields {
       writer.write_tag(1);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _v.encode(_w);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _v.encode(_w); });
     }
     writer.write_end_marker();
     writer.fill_message_length(pos);
@@ -879,9 +743,7 @@ impl<'buf> bebop::BebopEncode for Object<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.fields {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len()) + _v.encoded_size()
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + _v.encoded_size()));
     }
     size
   }
@@ -897,28 +759,10 @@ impl<'buf> bebop::BebopDecode<'buf> for Object<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.fields = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  JsonValue::decode(_r)?,
-                ))
-              })
-              .for_field("Object", "fields")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "Object",
-            tag,
-          });
-        }
+        1 => msg.fields = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, JsonValue::decode(_r)?))).for_field("Object", "fields")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "Object", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:Object)
@@ -927,10 +771,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Object<'buf> {
 }
 
 impl<'buf> Object<'buf> {
-  pub fn with_fields(
-    mut self,
-    value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, JsonValue<'buf>)>,
-  ) -> Self {
+  pub fn with_fields(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, JsonValue<'buf>)>) -> Self {
     self.fields = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v)).collect());
     self
   }
@@ -951,11 +792,7 @@ impl<'buf> Document<'buf> {
     Document {
       title: self.title.map(|v| borrow::Cow::Owned(v.into_owned())),
       body: self.body.map(|v| borrow::Cow::Owned(v.into_owned())),
-      metadata: self.metadata.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned()))
-          .collect()
-      }),
+      metadata: self.metadata.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned())).collect()),
     }
   }
 }
@@ -979,10 +816,7 @@ impl<'buf> bebop::BebopEncode for Document<'buf> {
     }
     if let option::Option::Some(ref v) = self.metadata {
       writer.write_tag(3);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _v.encode(_w);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _v.encode(_w); });
     }
     writer.write_end_marker();
     writer.fill_message_length(pos);
@@ -998,9 +832,7 @@ impl<'buf> bebop::BebopEncode for Document<'buf> {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
     }
     if let option::Option::Some(ref v) = self.metadata {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len()) + _v.encoded_size()
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + _v.encoded_size()));
     }
     size
   }
@@ -1016,38 +848,12 @@ impl<'buf> bebop::BebopDecode<'buf> for Document<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.title = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("Document", "title")?,
-          ))
-        }
-        2 => {
-          msg.body = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("Document", "body")?,
-          ))
-        }
-        3 => {
-          msg.metadata = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  JsonValue::decode(_r)?,
-                ))
-              })
-              .for_field("Document", "metadata")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "Document",
-            tag,
-          });
-        }
+        1 => msg.title = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Document", "title")?)),
+        2 => msg.body = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Document", "body")?)),
+        3 => msg.metadata = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, JsonValue::decode(_r)?))).for_field("Document", "metadata")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "Document", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:Document)
@@ -1064,12 +870,8 @@ impl<'buf> Document<'buf> {
     self.body = option::Option::Some(value.into());
     self
   }
-  pub fn with_metadata(
-    mut self,
-    value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, JsonValue<'buf>)>,
-  ) -> Self {
-    self.metadata =
-      option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v)).collect());
+  pub fn with_metadata(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, JsonValue<'buf>)>) -> Self {
+    self.metadata = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v)).collect());
     self
   }
   // @@bebop_insertion_point(message_scope:Document)
@@ -1092,18 +894,13 @@ impl convert::TryFrom<u8> for ChunkKind {
       1 => result::Result::Ok(Self::Paragraph),
       2 => result::Result::Ok(Self::Chapter),
       3 => result::Result::Ok(Self::Heading),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "ChunkKind",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "ChunkKind", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<ChunkKind> for u8 {
-  fn from(value: ChunkKind) -> u8 {
-    value as u8
-  }
+  fn from(value: ChunkKind) -> u8 { value as u8 }
 }
 
 impl ChunkKind {
@@ -1118,9 +915,7 @@ impl bebop::BebopEncode for ChunkKind {
     // @@bebop_insertion_point(encode_end:ChunkKind)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for ChunkKind {
@@ -1142,9 +937,15 @@ pub struct TextSpan {
 
 impl TextSpan {
   pub const FIXED_ENCODED_SIZE: usize =
-    mem::size_of::<u32>() + mem::size_of::<u32>() + ChunkKind::FIXED_ENCODED_SIZE;
+    mem::size_of::<u32>()
+    + mem::size_of::<u32>()
+    + ChunkKind::FIXED_ENCODED_SIZE;
 
-  pub fn new(start: u32, len: u32, kind: ChunkKind) -> Self {
+  pub fn new(
+    start: u32,
+    len: u32,
+    kind: ChunkKind,
+  ) -> Self {
     Self { start, len, kind }
   }
 }
@@ -1228,9 +1029,7 @@ impl<'buf> bebop::BebopDecode<'buf> for ChunkedText<'buf> {
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:ChunkedText)
     let source = borrow::Cow::Borrowed(reader.read_str().for_field("ChunkedText", "source")?);
-    let spans = reader
-      .read_array(|_r| TextSpan::decode(_r))
-      .for_field("ChunkedText", "spans")?;
+    let spans = reader.read_array(|_r| TextSpan::decode(_r)).for_field("ChunkedText", "spans")?;
     // @@bebop_insertion_point(decode_end:ChunkedText)
     result::Result::Ok(ChunkedText { source, spans })
   }
@@ -1288,9 +1087,7 @@ impl<'buf> bebop::BebopDecode<'buf> for EmbeddingBf16<'buf> {
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:EmbeddingBf16)
     let id = reader.read_uuid().for_field("EmbeddingBf16", "id")?;
-    let vector = reader
-      .read_scalar_array::<bebop::bf16>()
-      .for_field("EmbeddingBf16", "vector")?;
+    let vector = reader.read_scalar_array::<bebop::bf16>().for_field("EmbeddingBf16", "vector")?;
     // @@bebop_insertion_point(decode_end:EmbeddingBf16)
     result::Result::Ok(EmbeddingBf16 { id, vector })
   }
@@ -1309,7 +1106,10 @@ pub struct EmbeddingF32<'buf> {
 pub type EmbeddingF32Owned = EmbeddingF32<'static>;
 
 impl<'buf> EmbeddingF32<'buf> {
-  pub fn new(id: bebop::Uuid, vector: impl convert::Into<borrow::Cow<'buf, [f32]>>) -> Self {
+  pub fn new(
+    id: bebop::Uuid,
+    vector: impl convert::Into<borrow::Cow<'buf, [f32]>>,
+  ) -> Self {
     let vector = vector.into();
     Self { id, vector }
   }
@@ -1345,9 +1145,7 @@ impl<'buf> bebop::BebopDecode<'buf> for EmbeddingF32<'buf> {
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:EmbeddingF32)
     let id = reader.read_uuid().for_field("EmbeddingF32", "id")?;
-    let vector = reader
-      .read_scalar_array::<f32>()
-      .for_field("EmbeddingF32", "vector")?;
+    let vector = reader.read_scalar_array::<f32>().for_field("EmbeddingF32", "vector")?;
     // @@bebop_insertion_point(decode_end:EmbeddingF32)
     result::Result::Ok(EmbeddingF32 { id, vector })
   }
@@ -1374,11 +1172,7 @@ impl<'buf> EmbeddingBatch<'buf> {
   ) -> Self {
     let model = model.into();
     let embeddings = embeddings.into_iter().collect();
-    Self {
-      model,
-      embeddings,
-      usage_tokens,
-    }
+    Self { model, embeddings, usage_tokens }
   }
 }
 
@@ -1386,11 +1180,7 @@ impl<'buf> EmbeddingBatch<'buf> {
   pub fn into_owned(self) -> EmbeddingBatchOwned {
     EmbeddingBatch {
       model: borrow::Cow::Owned(self.model.into_owned()),
-      embeddings: self
-        .embeddings
-        .into_iter()
-        .map(|_e| _e.into_owned())
-        .collect(),
+      embeddings: self.embeddings.into_iter().map(|_e| _e.into_owned()).collect(),
       usage_tokens: self.usage_tokens,
     }
   }
@@ -1419,18 +1209,10 @@ impl<'buf> bebop::BebopDecode<'buf> for EmbeddingBatch<'buf> {
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:EmbeddingBatch)
     let model = borrow::Cow::Borrowed(reader.read_str().for_field("EmbeddingBatch", "model")?);
-    let embeddings = reader
-      .read_array(|_r| EmbeddingBf16::decode(_r))
-      .for_field("EmbeddingBatch", "embeddings")?;
-    let usage_tokens = reader
-      .read_u32()
-      .for_field("EmbeddingBatch", "usage_tokens")?;
+    let embeddings = reader.read_array(|_r| EmbeddingBf16::decode(_r)).for_field("EmbeddingBatch", "embeddings")?;
+    let usage_tokens = reader.read_u32().for_field("EmbeddingBatch", "usage_tokens")?;
     // @@bebop_insertion_point(decode_end:EmbeddingBatch)
-    result::Result::Ok(EmbeddingBatch {
-      model,
-      embeddings,
-      usage_tokens,
-    })
+    result::Result::Ok(EmbeddingBatch { model, embeddings, usage_tokens })
   }
 }
 
@@ -1454,11 +1236,7 @@ impl<'buf> TokenLogprob<'buf> {
     logprob: f32,
   ) -> Self {
     let token = token.into();
-    Self {
-      token,
-      token_id,
-      logprob,
-    }
+    Self { token, token_id, logprob }
   }
 }
 
@@ -1498,11 +1276,7 @@ impl<'buf> bebop::BebopDecode<'buf> for TokenLogprob<'buf> {
     let token_id = reader.read_u32().for_field("TokenLogprob", "token_id")?;
     let logprob = reader.read_f32().for_field("TokenLogprob", "logprob")?;
     // @@bebop_insertion_point(decode_end:TokenLogprob)
-    result::Result::Ok(TokenLogprob {
-      token,
-      token_id,
-      logprob,
-    })
+    result::Result::Ok(TokenLogprob { token, token_id, logprob })
   }
 }
 
@@ -1527,11 +1301,7 @@ impl<'buf> TokenAlternatives<'buf> {
 impl<'buf> TokenAlternatives<'buf> {
   pub fn into_owned(self) -> TokenAlternativesOwned {
     TokenAlternatives {
-      top_tokens: self
-        .top_tokens
-        .into_iter()
-        .map(|_e| _e.into_owned())
-        .collect(),
+      top_tokens: self.top_tokens.into_iter().map(|_e| _e.into_owned()).collect(),
     }
   }
 }
@@ -1554,9 +1324,7 @@ impl<'buf> bebop::BebopDecode<'buf> for TokenAlternatives<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TokenAlternatives)
-    let top_tokens = reader
-      .read_array(|_r| TokenLogprob::decode(_r))
-      .for_field("TokenAlternatives", "top_tokens")?;
+    let top_tokens = reader.read_array(|_r| TokenLogprob::decode(_r)).for_field("TokenAlternatives", "top_tokens")?;
     // @@bebop_insertion_point(decode_end:TokenAlternatives)
     result::Result::Ok(TokenAlternatives { top_tokens })
   }
@@ -1586,12 +1354,7 @@ impl<'buf> LlmStreamChunk<'buf> {
     let tokens = tokens.into_iter().map(|_e| _e.into()).collect();
     let logprobs = logprobs.into_iter().collect();
     let finish_reason = finish_reason.into();
-    Self {
-      chunk_id,
-      tokens,
-      logprobs,
-      finish_reason,
-    }
+    Self { chunk_id, tokens, logprobs, finish_reason }
   }
 }
 
@@ -1599,16 +1362,8 @@ impl<'buf> LlmStreamChunk<'buf> {
   pub fn into_owned(self) -> LlmStreamChunkOwned {
     LlmStreamChunk {
       chunk_id: self.chunk_id,
-      tokens: self
-        .tokens
-        .into_iter()
-        .map(|_e| borrow::Cow::Owned(_e.into_owned()))
-        .collect(),
-      logprobs: self
-        .logprobs
-        .into_iter()
-        .map(|_e| _e.into_owned())
-        .collect(),
+      tokens: self.tokens.into_iter().map(|_e| borrow::Cow::Owned(_e.into_owned())).collect(),
+      logprobs: self.logprobs.into_iter().map(|_e| _e.into_owned()).collect(),
       finish_reason: borrow::Cow::Owned(self.finish_reason.into_owned()),
     }
   }
@@ -1627,8 +1382,7 @@ impl<'buf> bebop::BebopEncode for LlmStreamChunk<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = 0;
     size += mem::size_of::<u32>();
-    size +=
-      bebop::wire_size::array_size(&self.tokens, |_el| bebop::wire_size::string_size(_el.len()));
+    size += bebop::wire_size::array_size(&self.tokens, |_el| bebop::wire_size::string_size(_el.len()));
     size += bebop::wire_size::array_size(&self.logprobs, |_el| _el.encoded_size());
     size += bebop::wire_size::string_size(self.finish_reason.len());
     size
@@ -1640,24 +1394,11 @@ impl<'buf> bebop::BebopDecode<'buf> for LlmStreamChunk<'buf> {
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:LlmStreamChunk)
     let chunk_id = reader.read_u32().for_field("LlmStreamChunk", "chunk_id")?;
-    let tokens = reader
-      .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
-      .for_field("LlmStreamChunk", "tokens")?;
-    let logprobs = reader
-      .read_array(|_r| TokenAlternatives::decode(_r))
-      .for_field("LlmStreamChunk", "logprobs")?;
-    let finish_reason = borrow::Cow::Borrowed(
-      reader
-        .read_str()
-        .for_field("LlmStreamChunk", "finish_reason")?,
-    );
+    let tokens = reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))).for_field("LlmStreamChunk", "tokens")?;
+    let logprobs = reader.read_array(|_r| TokenAlternatives::decode(_r)).for_field("LlmStreamChunk", "logprobs")?;
+    let finish_reason = borrow::Cow::Borrowed(reader.read_str().for_field("LlmStreamChunk", "finish_reason")?);
     // @@bebop_insertion_point(decode_end:LlmStreamChunk)
-    result::Result::Ok(LlmStreamChunk {
-      chunk_id,
-      tokens,
-      logprobs,
-      finish_reason,
-    })
+    result::Result::Ok(LlmStreamChunk { chunk_id, tokens, logprobs, finish_reason })
   }
 }
 
@@ -1690,14 +1431,7 @@ impl<'buf> TensorShard<'buf> {
     let shape = shape.into();
     let dtype = dtype.into();
     let data = data.into();
-    Self {
-      name,
-      shape,
-      dtype,
-      data,
-      offset,
-      total_elements,
-    }
+    Self { name, shape, dtype, data, offset, total_elements }
   }
 }
 
@@ -1743,26 +1477,13 @@ impl<'buf> bebop::BebopDecode<'buf> for TensorShard<'buf> {
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TensorShard)
     let name = borrow::Cow::Borrowed(reader.read_str().for_field("TensorShard", "name")?);
-    let shape = reader
-      .read_scalar_array::<u32>()
-      .for_field("TensorShard", "shape")?;
+    let shape = reader.read_scalar_array::<u32>().for_field("TensorShard", "shape")?;
     let dtype = borrow::Cow::Borrowed(reader.read_str().for_field("TensorShard", "dtype")?);
-    let data = reader
-      .read_scalar_array::<bebop::bf16>()
-      .for_field("TensorShard", "data")?;
+    let data = reader.read_scalar_array::<bebop::bf16>().for_field("TensorShard", "data")?;
     let offset = reader.read_u64().for_field("TensorShard", "offset")?;
-    let total_elements = reader
-      .read_u64()
-      .for_field("TensorShard", "total_elements")?;
+    let total_elements = reader.read_u64().for_field("TensorShard", "total_elements")?;
     // @@bebop_insertion_point(decode_end:TensorShard)
-    result::Result::Ok(TensorShard {
-      name,
-      shape,
-      dtype,
-      data,
-      offset,
-      total_elements,
-    })
+    result::Result::Ok(TensorShard { name, shape, dtype, data, offset, total_elements })
   }
 }
 
@@ -1778,10 +1499,9 @@ pub struct InferenceTiming {
 }
 
 impl InferenceTiming {
-  pub const FIXED_ENCODED_SIZE: usize = mem::size_of::<i64>()
-    + mem::size_of::<i32>()
-    + mem::size_of::<i64>()
-    + mem::size_of::<i32>()
+  pub const FIXED_ENCODED_SIZE: usize =
+    mem::size_of::<i64>() + mem::size_of::<i32>()
+    + mem::size_of::<i64>() + mem::size_of::<i32>()
     + mem::size_of::<f32>();
 
   pub fn new(
@@ -1789,11 +1509,7 @@ impl InferenceTiming {
     inference_time: bebop::BebopDuration,
     tokens_per_second: f32,
   ) -> Self {
-    Self {
-      queue_time,
-      inference_time,
-      tokens_per_second,
-    }
+    Self { queue_time, inference_time, tokens_per_second }
   }
 }
 
@@ -1815,21 +1531,11 @@ impl<'buf> bebop::BebopDecode<'buf> for InferenceTiming {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:InferenceTiming)
-    let queue_time = reader
-      .read_duration()
-      .for_field("InferenceTiming", "queue_time")?;
-    let inference_time = reader
-      .read_duration()
-      .for_field("InferenceTiming", "inference_time")?;
-    let tokens_per_second = reader
-      .read_f32()
-      .for_field("InferenceTiming", "tokens_per_second")?;
+    let queue_time = reader.read_duration().for_field("InferenceTiming", "queue_time")?;
+    let inference_time = reader.read_duration().for_field("InferenceTiming", "inference_time")?;
+    let tokens_per_second = reader.read_f32().for_field("InferenceTiming", "tokens_per_second")?;
     // @@bebop_insertion_point(decode_end:InferenceTiming)
-    result::Result::Ok(InferenceTiming {
-      queue_time,
-      inference_time,
-      tokens_per_second,
-    })
+    result::Result::Ok(InferenceTiming { queue_time, inference_time, tokens_per_second })
   }
 }
 
@@ -1853,11 +1559,7 @@ impl<'buf> InferenceResponse<'buf> {
     timing: InferenceTiming,
   ) -> Self {
     let embeddings = embeddings.into_iter().collect();
-    Self {
-      request_id,
-      embeddings,
-      timing,
-    }
+    Self { request_id, embeddings, timing }
   }
 }
 
@@ -1865,11 +1567,7 @@ impl<'buf> InferenceResponse<'buf> {
   pub fn into_owned(self) -> InferenceResponseOwned {
     InferenceResponse {
       request_id: self.request_id,
-      embeddings: self
-        .embeddings
-        .into_iter()
-        .map(|_e| _e.into_owned())
-        .collect(),
+      embeddings: self.embeddings.into_iter().map(|_e| _e.into_owned()).collect(),
       timing: self.timing,
     }
   }
@@ -1897,19 +1595,11 @@ impl<'buf> bebop::BebopDecode<'buf> for InferenceResponse<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:InferenceResponse)
-    let request_id = reader
-      .read_uuid()
-      .for_field("InferenceResponse", "request_id")?;
-    let embeddings = reader
-      .read_array(|_r| EmbeddingBf16::decode(_r))
-      .for_field("InferenceResponse", "embeddings")?;
+    let request_id = reader.read_uuid().for_field("InferenceResponse", "request_id")?;
+    let embeddings = reader.read_array(|_r| EmbeddingBf16::decode(_r)).for_field("InferenceResponse", "embeddings")?;
     let timing = InferenceTiming::decode(reader).for_field("InferenceResponse", "timing")?;
     // @@bebop_insertion_point(decode_end:InferenceResponse)
-    result::Result::Ok(InferenceResponse {
-      request_id,
-      embeddings,
-      timing,
-    })
+    result::Result::Ok(InferenceResponse { request_id, embeddings, timing })
   }
 }
 

--- a/plugins/rust/generate.sh
+++ b/plugins/rust/generate.sh
@@ -33,7 +33,6 @@ echo "Generating descriptor.rs + plugin.rs..."
 mkdir -p "$RUST_DIR/src/generated"
 cp "$TMPDIR/bootstrap/descriptor.rs" "$RUST_DIR/src/generated/descriptor.rs"
 cp "$TMPDIR/bootstrap/plugin.rs" "$RUST_DIR/src/generated/plugin.rs"
-rustfmt "$RUST_DIR/src/generated/descriptor.rs" "$RUST_DIR/src/generated/plugin.rs"
 
 # ── 2. Integration tests: test_types.rs ──────────────────────────────
 
@@ -47,7 +46,6 @@ echo "Generating test_types.rs..."
   -q 2>/dev/null
 
 cp "$TMPDIR/integration/test_types.rs" "$RUST_DIR/integration-tests/src/test_types.rs"
-rustfmt "$RUST_DIR/integration-tests/src/test_types.rs"
 
 echo "Generating collision_types.rs..."
 "$BEBOPC" build \
@@ -59,7 +57,6 @@ echo "Generating collision_types.rs..."
   -q 2>/dev/null
 
 cp "$TMPDIR/collision/collision_types.rs" "$RUST_DIR/integration-tests/src/collision_types.rs"
-rustfmt "$RUST_DIR/integration-tests/src/collision_types.rs"
 
 # ── 3. Benchmarks: benchmark_types.rs ────────────────────────────────
 
@@ -72,6 +69,5 @@ echo "Generating benchmark_types.rs..."
   -q 2>/dev/null
 
 cp "$TMPDIR/bench/benchmark.rs" "$RUST_DIR/benchmarks/src/benchmark_types.rs"
-rustfmt "$RUST_DIR/benchmarks/src/benchmark_types.rs"
 
 echo "Done. Regenerated all generated files."

--- a/plugins/rust/integration-tests/src/collision_types.rs
+++ b/plugins/rust/integration-tests/src/collision_types.rs
@@ -5808,9 +5808,9 @@ impl<'buf> bebop::BebopDecode<'buf> for RustKeywordFields {
     // @@bebop_insertion_point(decode_start:RustKeywordFields)
     let r#type = reader.read_i32().for_field("RustKeywordFields", "type")?;
     let r#mod = reader.read_i32().for_field("RustKeywordFields", "mod")?;
-    let self_ = reader.read_i32().for_field("RustKeywordFields", "self_")?;
-    let super_ = reader.read_i32().for_field("RustKeywordFields", "super_")?;
-    let crate_ = reader.read_i32().for_field("RustKeywordFields", "crate_")?;
+    let self_ = reader.read_i32().for_field("RustKeywordFields", "self")?;
+    let super_ = reader.read_i32().for_field("RustKeywordFields", "super")?;
+    let crate_ = reader.read_i32().for_field("RustKeywordFields", "crate")?;
     let r#match = reader.read_i32().for_field("RustKeywordFields", "match")?;
     let r#where = reader.read_i32().for_field("RustKeywordFields", "where")?;
     let r#loop = reader.read_i32().for_field("RustKeywordFields", "loop")?;
@@ -6170,14 +6170,14 @@ impl<'buf> bebop::BebopDecode<'buf> for KeywordFieldMessage<'buf> {
           msg.self_ = option::Option::Some(
             reader
               .read_bool()
-              .for_field("KeywordFieldMessage", "self_")?,
+              .for_field("KeywordFieldMessage", "self")?,
           )
         }
         4 => {
           msg.crate_ = option::Option::Some(
             reader
               .read_i32()
-              .for_field("KeywordFieldMessage", "crate_")?,
+              .for_field("KeywordFieldMessage", "crate")?,
           )
         }
         tag => {

--- a/plugins/rust/integration-tests/src/collision_types.rs
+++ b/plugins/rust/integration-tests/src/collision_types.rs
@@ -17,16 +17,17 @@ extern crate bebop_runtime;
 extern crate core;
 use alloc::{borrow, boxed, string, vec};
 use bebop_runtime as bebop;
-use bebop_runtime::serde;
 use bebop_runtime::DecodeContext as _;
 use core::convert::Into as _;
 use core::iter::{IntoIterator as _, Iterator as _};
 use core::{convert, default, iter, mem, ops, option, result};
+use bebop_runtime::serde;
 
 // @@bebop_insertion_point(imports)
 
 /// Same wire layout as `Point` in test_types.bop; used by `KeywordUnion` only.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Point {
   pub x: f32,
   pub y: f32,
@@ -35,7 +36,10 @@ pub struct Point {
 impl Point {
   pub const FIXED_ENCODED_SIZE: usize = mem::size_of::<f32>() + mem::size_of::<f32>();
 
-  pub fn new(x: f32, y: f32) -> Self {
+  pub fn new(
+    x: f32,
+    y: f32,
+  ) -> Self {
     Self { x, y }
   }
 }
@@ -68,7 +72,8 @@ impl Point {
   // @@bebop_insertion_point(struct_scope:Point)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Uuid {
   pub tag: i32,
 }
@@ -107,7 +112,8 @@ impl Uuid {
   // @@bebop_insertion_point(struct_scope:Uuid)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct HashMap {
   pub tag: i32,
 }
@@ -146,7 +152,8 @@ impl HashMap {
   // @@bebop_insertion_point(struct_scope:HashMap)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DecodeError {
   pub tag: i32,
 }
@@ -185,7 +192,8 @@ impl DecodeError {
   // @@bebop_insertion_point(struct_scope:DecodeError)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BebopReader {
   pub tag: i32,
 }
@@ -224,7 +232,8 @@ impl BebopReader {
   // @@bebop_insertion_point(struct_scope:BebopReader)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BebopWriter {
   pub tag: i32,
 }
@@ -263,7 +272,8 @@ impl BebopWriter {
   // @@bebop_insertion_point(struct_scope:BebopWriter)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BebopDecode {
   pub tag: i32,
 }
@@ -302,7 +312,8 @@ impl BebopDecode {
   // @@bebop_insertion_point(struct_scope:BebopDecode)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BebopEncode {
   pub tag: i32,
 }
@@ -341,7 +352,8 @@ impl BebopEncode {
   // @@bebop_insertion_point(struct_scope:BebopEncode)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BebopDuration {
   pub tag: i32,
 }
@@ -380,7 +392,8 @@ impl BebopDuration {
   // @@bebop_insertion_point(struct_scope:BebopDuration)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BebopTimestamp {
   pub tag: i32,
 }
@@ -419,7 +432,8 @@ impl BebopTimestamp {
   // @@bebop_insertion_point(struct_scope:BebopTimestamp)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BebopFlags {
   pub tag: i32,
 }
@@ -458,7 +472,8 @@ impl BebopFlags {
   // @@bebop_insertion_point(struct_scope:BebopFlags)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BebopBytes {
   pub tag: i32,
 }
@@ -497,7 +512,8 @@ impl BebopBytes {
   // @@bebop_insertion_point(struct_scope:BebopBytes)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Serde {
   pub tag: i32,
 }
@@ -536,7 +552,8 @@ impl Serde {
   // @@bebop_insertion_point(struct_scope:Serde)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Wire {
   pub tag: i32,
 }
@@ -575,7 +592,8 @@ impl Wire {
   // @@bebop_insertion_point(struct_scope:Wire)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Mod {
   pub tag: i32,
 }
@@ -614,7 +632,8 @@ impl Mod {
   // @@bebop_insertion_point(struct_scope:Mod)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Trait {
   pub tag: i32,
 }
@@ -653,7 +672,8 @@ impl Trait {
   // @@bebop_insertion_point(struct_scope:Trait)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Impl {
   pub tag: i32,
 }
@@ -692,7 +712,8 @@ impl Impl {
   // @@bebop_insertion_point(struct_scope:Impl)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Fn {
   pub tag: i32,
 }
@@ -731,7 +752,8 @@ impl Fn {
   // @@bebop_insertion_point(struct_scope:Fn)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Let {
   pub tag: i32,
 }
@@ -770,7 +792,8 @@ impl Let {
   // @@bebop_insertion_point(struct_scope:Let)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Use {
   pub tag: i32,
 }
@@ -809,7 +832,8 @@ impl Use {
   // @@bebop_insertion_point(struct_scope:Use)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Crate {
   pub tag: i32,
 }
@@ -848,7 +872,8 @@ impl Crate {
   // @@bebop_insertion_point(struct_scope:Crate)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Async {
   pub tag: i32,
 }
@@ -887,7 +912,8 @@ impl Async {
   // @@bebop_insertion_point(struct_scope:Async)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Await {
   pub tag: i32,
 }
@@ -926,7 +952,8 @@ impl Await {
   // @@bebop_insertion_point(struct_scope:Await)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Match {
   pub tag: i32,
 }
@@ -965,7 +992,8 @@ impl Match {
   // @@bebop_insertion_point(struct_scope:Match)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Where {
   pub tag: i32,
 }
@@ -1004,7 +1032,8 @@ impl Where {
   // @@bebop_insertion_point(struct_scope:Where)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Loop {
   pub tag: i32,
 }
@@ -1043,7 +1072,8 @@ impl Loop {
   // @@bebop_insertion_point(struct_scope:Loop)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Move {
   pub tag: i32,
 }
@@ -1082,7 +1112,8 @@ impl Move {
   // @@bebop_insertion_point(struct_scope:Move)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Ref {
   pub tag: i32,
 }
@@ -1121,7 +1152,8 @@ impl Ref {
   // @@bebop_insertion_point(struct_scope:Ref)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Dyn {
   pub tag: i32,
 }
@@ -1160,7 +1192,8 @@ impl Dyn {
   // @@bebop_insertion_point(struct_scope:Dyn)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Yield {
   pub tag: i32,
 }
@@ -1199,7 +1232,8 @@ impl Yield {
   // @@bebop_insertion_point(struct_scope:Yield)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Unsafe {
   pub tag: i32,
 }
@@ -1238,7 +1272,8 @@ impl Unsafe {
   // @@bebop_insertion_point(struct_scope:Unsafe)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Extern {
   pub tag: i32,
 }
@@ -1277,7 +1312,8 @@ impl Extern {
   // @@bebop_insertion_point(struct_scope:Extern)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Static {
   pub tag: i32,
 }
@@ -1316,7 +1352,8 @@ impl Static {
   // @@bebop_insertion_point(struct_scope:Static)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Virtual {
   pub tag: i32,
 }
@@ -1355,7 +1392,8 @@ impl Virtual {
   // @@bebop_insertion_point(struct_scope:Virtual)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Override {
   pub tag: i32,
 }
@@ -1394,7 +1432,8 @@ impl Override {
   // @@bebop_insertion_point(struct_scope:Override)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Final {
   pub tag: i32,
 }
@@ -1433,7 +1472,8 @@ impl Final {
   // @@bebop_insertion_point(struct_scope:Final)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Abstract {
   pub tag: i32,
 }
@@ -1472,7 +1512,8 @@ impl Abstract {
   // @@bebop_insertion_point(struct_scope:Abstract)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Self_ {
   pub tag: i32,
 }
@@ -1511,7 +1552,8 @@ impl Self_ {
   // @@bebop_insertion_point(struct_scope:Self_)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Super {
   pub tag: i32,
 }
@@ -1550,7 +1592,8 @@ impl Super {
   // @@bebop_insertion_point(struct_scope:Super)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Type {
   pub tag: i32,
 }
@@ -1589,7 +1632,8 @@ impl Type {
   // @@bebop_insertion_point(struct_scope:Type)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct For {
   pub tag: i32,
 }
@@ -1628,7 +1672,8 @@ impl For {
   // @@bebop_insertion_point(struct_scope:For)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Interface {
   pub tag: i32,
 }
@@ -1667,7 +1712,8 @@ impl Interface {
   // @@bebop_insertion_point(struct_scope:Interface)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Namespace {
   pub tag: i32,
 }
@@ -1706,7 +1752,8 @@ impl Namespace {
   // @@bebop_insertion_point(struct_scope:Namespace)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Default {
   pub tag: i32,
 }
@@ -1745,7 +1792,8 @@ impl Default {
   // @@bebop_insertion_point(struct_scope:Default)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Switch {
   pub tag: i32,
 }
@@ -1784,7 +1832,8 @@ impl Switch {
   // @@bebop_insertion_point(struct_scope:Switch)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Case {
   pub tag: i32,
 }
@@ -1823,7 +1872,8 @@ impl Case {
   // @@bebop_insertion_point(struct_scope:Case)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Goto {
   pub tag: i32,
 }
@@ -1862,7 +1912,8 @@ impl Goto {
   // @@bebop_insertion_point(struct_scope:Goto)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Volatile {
   pub tag: i32,
 }
@@ -1901,7 +1952,8 @@ impl Volatile {
   // @@bebop_insertion_point(struct_scope:Volatile)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Synchronized {
   pub tag: i32,
 }
@@ -1940,7 +1992,8 @@ impl Synchronized {
   // @@bebop_insertion_point(struct_scope:Synchronized)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Transient {
   pub tag: i32,
 }
@@ -1979,7 +2032,8 @@ impl Transient {
   // @@bebop_insertion_point(struct_scope:Transient)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Native {
   pub tag: i32,
 }
@@ -2018,7 +2072,8 @@ impl Native {
   // @@bebop_insertion_point(struct_scope:Native)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Throws {
   pub tag: i32,
 }
@@ -2057,7 +2112,8 @@ impl Throws {
   // @@bebop_insertion_point(struct_scope:Throws)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Strictfp {
   pub tag: i32,
 }
@@ -2096,7 +2152,8 @@ impl Strictfp {
   // @@bebop_insertion_point(struct_scope:Strictfp)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Assert {
   pub tag: i32,
 }
@@ -2135,7 +2192,8 @@ impl Assert {
   // @@bebop_insertion_point(struct_scope:Assert)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Sizeof {
   pub tag: i32,
 }
@@ -2174,7 +2232,8 @@ impl Sizeof {
   // @@bebop_insertion_point(struct_scope:Sizeof)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Typeof {
   pub tag: i32,
 }
@@ -2213,7 +2272,8 @@ impl Typeof {
   // @@bebop_insertion_point(struct_scope:Typeof)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Nullptr {
   pub tag: i32,
 }
@@ -2252,7 +2312,8 @@ impl Nullptr {
   // @@bebop_insertion_point(struct_scope:Nullptr)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Decltype {
   pub tag: i32,
 }
@@ -2291,7 +2352,8 @@ impl Decltype {
   // @@bebop_insertion_point(struct_scope:Decltype)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Constexpr {
   pub tag: i32,
 }
@@ -2330,7 +2392,8 @@ impl Constexpr {
   // @@bebop_insertion_point(struct_scope:Constexpr)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Noexcept {
   pub tag: i32,
 }
@@ -2369,7 +2432,8 @@ impl Noexcept {
   // @@bebop_insertion_point(struct_scope:Noexcept)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Template {
   pub tag: i32,
 }
@@ -2408,7 +2472,8 @@ impl Template {
   // @@bebop_insertion_point(struct_scope:Template)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Typename {
   pub tag: i32,
 }
@@ -2447,7 +2512,8 @@ impl Typename {
   // @@bebop_insertion_point(struct_scope:Typename)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Friend {
   pub tag: i32,
 }
@@ -2486,7 +2552,8 @@ impl Friend {
   // @@bebop_insertion_point(struct_scope:Friend)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Inline {
   pub tag: i32,
 }
@@ -2525,7 +2592,8 @@ impl Inline {
   // @@bebop_insertion_point(struct_scope:Inline)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Mutable {
   pub tag: i32,
 }
@@ -2564,7 +2632,8 @@ impl Mutable {
   // @@bebop_insertion_point(struct_scope:Mutable)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Explicit {
   pub tag: i32,
 }
@@ -2603,7 +2672,8 @@ impl Explicit {
   // @@bebop_insertion_point(struct_scope:Explicit)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Implicit {
   pub tag: i32,
 }
@@ -2642,7 +2712,8 @@ impl Implicit {
   // @@bebop_insertion_point(struct_scope:Implicit)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Operator {
   pub tag: i32,
 }
@@ -2681,7 +2752,8 @@ impl Operator {
   // @@bebop_insertion_point(struct_scope:Operator)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Delete {
   pub tag: i32,
 }
@@ -2720,7 +2792,8 @@ impl Delete {
   // @@bebop_insertion_point(struct_scope:Delete)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct New {
   pub tag: i32,
 }
@@ -2759,7 +2832,8 @@ impl New {
   // @@bebop_insertion_point(struct_scope:New)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct This {
   pub tag: i32,
 }
@@ -2798,7 +2872,8 @@ impl This {
   // @@bebop_insertion_point(struct_scope:This)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Extends {
   pub tag: i32,
 }
@@ -2837,7 +2912,8 @@ impl Extends {
   // @@bebop_insertion_point(struct_scope:Extends)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Implements {
   pub tag: i32,
 }
@@ -2876,7 +2952,8 @@ impl Implements {
   // @@bebop_insertion_point(struct_scope:Implements)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Instanceof {
   pub tag: i32,
 }
@@ -2915,7 +2992,8 @@ impl Instanceof {
   // @@bebop_insertion_point(struct_scope:Instanceof)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Boolean {
   pub tag: i32,
 }
@@ -2954,7 +3032,8 @@ impl Boolean {
   // @@bebop_insertion_point(struct_scope:Boolean)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Byte {
   pub tag: i32,
 }
@@ -2993,7 +3072,8 @@ impl Byte {
   // @@bebop_insertion_point(struct_scope:Byte)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Short {
   pub tag: i32,
 }
@@ -3032,7 +3112,8 @@ impl Short {
   // @@bebop_insertion_point(struct_scope:Short)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Long {
   pub tag: i32,
 }
@@ -3071,7 +3152,8 @@ impl Long {
   // @@bebop_insertion_point(struct_scope:Long)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Double {
   pub tag: i32,
 }
@@ -3110,7 +3192,8 @@ impl Double {
   // @@bebop_insertion_point(struct_scope:Double)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Float {
   pub tag: i32,
 }
@@ -3149,7 +3232,8 @@ impl Float {
   // @@bebop_insertion_point(struct_scope:Float)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Char {
   pub tag: i32,
 }
@@ -3188,7 +3272,8 @@ impl Char {
   // @@bebop_insertion_point(struct_scope:Char)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Void {
   pub tag: i32,
 }
@@ -3227,7 +3312,8 @@ impl Void {
   // @@bebop_insertion_point(struct_scope:Void)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Int {
   pub tag: i32,
 }
@@ -3266,7 +3352,8 @@ impl Int {
   // @@bebop_insertion_point(struct_scope:Int)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Var {
   pub tag: i32,
 }
@@ -3305,7 +3392,8 @@ impl Var {
   // @@bebop_insertion_point(struct_scope:Var)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Function {
   pub tag: i32,
 }
@@ -3344,7 +3432,8 @@ impl Function {
   // @@bebop_insertion_point(struct_scope:Function)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Debugger {
   pub tag: i32,
 }
@@ -3383,7 +3472,8 @@ impl Debugger {
   // @@bebop_insertion_point(struct_scope:Debugger)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Undefined {
   pub tag: i32,
 }
@@ -3422,7 +3512,8 @@ impl Undefined {
   // @@bebop_insertion_point(struct_scope:Undefined)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Declare {
   pub tag: i32,
 }
@@ -3461,7 +3552,8 @@ impl Declare {
   // @@bebop_insertion_point(struct_scope:Declare)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Require {
   pub tag: i32,
 }
@@ -3500,7 +3592,8 @@ impl Require {
   // @@bebop_insertion_point(struct_scope:Require)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Module {
   pub tag: i32,
 }
@@ -3539,7 +3632,8 @@ impl Module {
   // @@bebop_insertion_point(struct_scope:Module)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Global {
   pub tag: i32,
 }
@@ -3578,7 +3672,8 @@ impl Global {
   // @@bebop_insertion_point(struct_scope:Global)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Internal {
   pub tag: i32,
 }
@@ -3617,7 +3712,8 @@ impl Internal {
   // @@bebop_insertion_point(struct_scope:Internal)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Object {
   pub tag: i32,
 }
@@ -3656,7 +3752,8 @@ impl Object {
   // @@bebop_insertion_point(struct_scope:Object)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct String {
   pub tag: i32,
 }
@@ -3695,7 +3792,8 @@ impl String {
   // @@bebop_insertion_point(struct_scope:String)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Symbol {
   pub tag: i32,
 }
@@ -3734,7 +3832,8 @@ impl Symbol {
   // @@bebop_insertion_point(struct_scope:Symbol)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Bigint {
   pub tag: i32,
 }
@@ -3773,7 +3872,8 @@ impl Bigint {
   // @@bebop_insertion_point(struct_scope:Bigint)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Never {
   pub tag: i32,
 }
@@ -3812,7 +3912,8 @@ impl Never {
   // @@bebop_insertion_point(struct_scope:Never)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Unknown {
   pub tag: i32,
 }
@@ -3851,7 +3952,8 @@ impl Unknown {
   // @@bebop_insertion_point(struct_scope:Unknown)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Keyof {
   pub tag: i32,
 }
@@ -3890,7 +3992,8 @@ impl Keyof {
   // @@bebop_insertion_point(struct_scope:Keyof)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Infer {
   pub tag: i32,
 }
@@ -3929,7 +4032,8 @@ impl Infer {
   // @@bebop_insertion_point(struct_scope:Infer)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Satisfies {
   pub tag: i32,
 }
@@ -3968,7 +4072,8 @@ impl Satisfies {
   // @@bebop_insertion_point(struct_scope:Satisfies)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Out {
   pub tag: i32,
 }
@@ -4007,7 +4112,8 @@ impl Out {
   // @@bebop_insertion_point(struct_scope:Out)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Inout {
   pub tag: i32,
 }
@@ -4046,7 +4152,8 @@ impl Inout {
   // @@bebop_insertion_point(struct_scope:Inout)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Protocol {
   pub tag: i32,
 }
@@ -4085,7 +4192,8 @@ impl Protocol {
   // @@bebop_insertion_point(struct_scope:Protocol)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Subscript {
   pub tag: i32,
 }
@@ -4124,7 +4232,8 @@ impl Subscript {
   // @@bebop_insertion_point(struct_scope:Subscript)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Defer {
   pub tag: i32,
 }
@@ -4163,7 +4272,8 @@ impl Defer {
   // @@bebop_insertion_point(struct_scope:Defer)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Fallthrough {
   pub tag: i32,
 }
@@ -4202,7 +4312,8 @@ impl Fallthrough {
   // @@bebop_insertion_point(struct_scope:Fallthrough)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Repeat {
   pub tag: i32,
 }
@@ -4241,7 +4352,8 @@ impl Repeat {
   // @@bebop_insertion_point(struct_scope:Repeat)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Indirect {
   pub tag: i32,
 }
@@ -4280,7 +4392,8 @@ impl Indirect {
   // @@bebop_insertion_point(struct_scope:Indirect)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Nonisolated {
   pub tag: i32,
 }
@@ -4319,7 +4432,8 @@ impl Nonisolated {
   // @@bebop_insertion_point(struct_scope:Nonisolated)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Lazy {
   pub tag: i32,
 }
@@ -4358,7 +4472,8 @@ impl Lazy {
   // @@bebop_insertion_point(struct_scope:Lazy)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Weak {
   pub tag: i32,
 }
@@ -4397,7 +4512,8 @@ impl Weak {
   // @@bebop_insertion_point(struct_scope:Weak)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Unowned {
   pub tag: i32,
 }
@@ -4436,7 +4552,8 @@ impl Unowned {
   // @@bebop_insertion_point(struct_scope:Unowned)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Convenience {
   pub tag: i32,
 }
@@ -4475,7 +4592,8 @@ impl Convenience {
   // @@bebop_insertion_point(struct_scope:Convenience)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Required {
   pub tag: i32,
 }
@@ -4514,7 +4632,8 @@ impl Required {
   // @@bebop_insertion_point(struct_scope:Required)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Optional {
   pub tag: i32,
 }
@@ -4553,7 +4672,8 @@ impl Optional {
   // @@bebop_insertion_point(struct_scope:Optional)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Rethrows {
   pub tag: i32,
 }
@@ -4592,7 +4712,8 @@ impl Rethrows {
   // @@bebop_insertion_point(struct_scope:Rethrows)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Try {
   pub tag: i32,
 }
@@ -4631,7 +4752,8 @@ impl Try {
   // @@bebop_insertion_point(struct_scope:Try)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Catch {
   pub tag: i32,
 }
@@ -4670,7 +4792,8 @@ impl Catch {
   // @@bebop_insertion_point(struct_scope:Catch)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Throw {
   pub tag: i32,
 }
@@ -4709,7 +4832,8 @@ impl Throw {
   // @@bebop_insertion_point(struct_scope:Throw)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Guard {
   pub tag: i32,
 }
@@ -4748,7 +4872,8 @@ impl Guard {
   // @@bebop_insertion_point(struct_scope:Guard)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct In {
   pub tag: i32,
 }
@@ -4787,7 +4912,8 @@ impl In {
   // @@bebop_insertion_point(struct_scope:In)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Is {
   pub tag: i32,
 }
@@ -4826,7 +4952,8 @@ impl Is {
   // @@bebop_insertion_point(struct_scope:Is)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct As {
   pub tag: i32,
 }
@@ -4865,7 +4992,8 @@ impl As {
   // @@bebop_insertion_point(struct_scope:As)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Select {
   pub tag: i32,
 }
@@ -4904,7 +5032,8 @@ impl Select {
   // @@bebop_insertion_point(struct_scope:Select)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Event {
   pub tag: i32,
 }
@@ -4943,7 +5072,8 @@ impl Event {
   // @@bebop_insertion_point(struct_scope:Event)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Delegate {
   pub tag: i32,
 }
@@ -4982,7 +5112,8 @@ impl Delegate {
   // @@bebop_insertion_point(struct_scope:Delegate)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Checked {
   pub tag: i32,
 }
@@ -5021,7 +5152,8 @@ impl Checked {
   // @@bebop_insertion_point(struct_scope:Checked)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Unchecked {
   pub tag: i32,
 }
@@ -5060,7 +5192,8 @@ impl Unchecked {
   // @@bebop_insertion_point(struct_scope:Unchecked)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Stackalloc {
   pub tag: i32,
 }
@@ -5099,7 +5232,8 @@ impl Stackalloc {
   // @@bebop_insertion_point(struct_scope:Stackalloc)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Params {
   pub tag: i32,
 }
@@ -5138,7 +5272,8 @@ impl Params {
   // @@bebop_insertion_point(struct_scope:Params)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Lock {
   pub tag: i32,
 }
@@ -5177,7 +5312,8 @@ impl Lock {
   // @@bebop_insertion_point(struct_scope:Lock)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Nameof {
   pub tag: i32,
 }
@@ -5216,7 +5352,8 @@ impl Nameof {
   // @@bebop_insertion_point(struct_scope:Nameof)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Sbyte {
   pub tag: i32,
 }
@@ -5255,7 +5392,8 @@ impl Sbyte {
   // @@bebop_insertion_point(struct_scope:Sbyte)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Ushort {
   pub tag: i32,
 }
@@ -5294,7 +5432,8 @@ impl Ushort {
   // @@bebop_insertion_point(struct_scope:Ushort)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Uint {
   pub tag: i32,
 }
@@ -5333,7 +5472,8 @@ impl Uint {
   // @@bebop_insertion_point(struct_scope:Uint)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Ulong {
   pub tag: i32,
 }
@@ -5372,7 +5512,8 @@ impl Ulong {
   // @@bebop_insertion_point(struct_scope:Ulong)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct When {
   pub tag: i32,
 }
@@ -5411,7 +5552,8 @@ impl When {
   // @@bebop_insertion_point(struct_scope:When)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Init {
   pub tag: i32,
 }
@@ -5450,7 +5592,8 @@ impl Init {
   // @@bebop_insertion_point(struct_scope:Init)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Deinit {
   pub tag: i32,
 }
@@ -5489,7 +5632,8 @@ impl Deinit {
   // @@bebop_insertion_point(struct_scope:Deinit)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Get {
   pub tag: i32,
 }
@@ -5528,7 +5672,8 @@ impl Get {
   // @@bebop_insertion_point(struct_scope:Get)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Set {
   pub tag: i32,
 }
@@ -5567,7 +5712,8 @@ impl Set {
   // @@bebop_insertion_point(struct_scope:Set)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WillSet {
   pub tag: i32,
 }
@@ -5606,7 +5752,8 @@ impl WillSet {
   // @@bebop_insertion_point(struct_scope:WillSet)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DidSet {
   pub tag: i32,
 }
@@ -5645,7 +5792,8 @@ impl DidSet {
   // @@bebop_insertion_point(struct_scope:DidSet)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Associatedtype {
   pub tag: i32,
 }
@@ -5685,7 +5833,8 @@ impl Associatedtype {
 }
 
 /// Many Rust / Swift / C# keywords reused as *field* names (snake_case in Rust).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RustKeywordFields {
   pub r#type: i32,
   pub r#mod: i32,
@@ -5711,7 +5860,8 @@ pub struct RustKeywordFields {
 }
 
 impl RustKeywordFields {
-  pub const FIXED_ENCODED_SIZE: usize = mem::size_of::<i32>()
+  pub const FIXED_ENCODED_SIZE: usize =
+    mem::size_of::<i32>()
     + mem::size_of::<i32>()
     + mem::size_of::<i32>()
     + mem::size_of::<i32>()
@@ -5750,26 +5900,7 @@ impl RustKeywordFields {
     is: i32,
     r#try: i32,
   ) -> Self {
-    Self {
-      r#type,
-      r#mod,
-      self_,
-      super_,
-      crate_,
-      r#match,
-      r#where,
-      r#loop,
-      r#move,
-      r#ref,
-      r#dyn,
-      r#use,
-      r#let,
-      r#fn,
-      r#as,
-      r#in,
-      is,
-      r#try,
-    }
+    Self { r#type, r#mod, self_, super_, crate_, r#match, r#where, r#loop, r#move, r#ref, r#dyn, r#use, r#let, r#fn, r#as, r#in, is, r#try }
   }
 }
 
@@ -5825,26 +5956,7 @@ impl<'buf> bebop::BebopDecode<'buf> for RustKeywordFields {
     let is = reader.read_i32().for_field("RustKeywordFields", "is")?;
     let r#try = reader.read_i32().for_field("RustKeywordFields", "try")?;
     // @@bebop_insertion_point(decode_end:RustKeywordFields)
-    result::Result::Ok(RustKeywordFields {
-      r#type,
-      r#mod,
-      self_,
-      super_,
-      crate_,
-      r#match,
-      r#where,
-      r#loop,
-      r#move,
-      r#ref,
-      r#dyn,
-      r#use,
-      r#let,
-      r#fn,
-      r#as,
-      r#in,
-      is,
-      r#try,
-    })
+    result::Result::Ok(RustKeywordFields { r#type, r#mod, self_, super_, crate_, r#match, r#where, r#loop, r#move, r#ref, r#dyn, r#use, r#let, r#fn, r#as, r#in, is, r#try })
   }
 }
 
@@ -5861,7 +5973,8 @@ pub const RETURN: u32 = 2u32;
 pub const ELSE: u32 = 3u32;
 
 #[repr(u8)]
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MultiLangKeywordVariant {
   Mod = 0,
   Match = 1,
@@ -5887,18 +6000,13 @@ impl convert::TryFrom<u8> for MultiLangKeywordVariant {
       6 => result::Result::Ok(Self::Async),
       7 => result::Result::Ok(Self::Self_),
       8 => result::Result::Ok(Self::Super),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "MultiLangKeywordVariant",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "MultiLangKeywordVariant", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<MultiLangKeywordVariant> for u8 {
-  fn from(value: MultiLangKeywordVariant) -> u8 {
-    value as u8
-  }
+  fn from(value: MultiLangKeywordVariant) -> u8 { value as u8 }
 }
 
 impl MultiLangKeywordVariant {
@@ -5913,9 +6021,7 @@ impl bebop::BebopEncode for MultiLangKeywordVariant {
     // @@bebop_insertion_point(encode_end:MultiLangKeywordVariant)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for MultiLangKeywordVariant {
@@ -5928,7 +6034,8 @@ impl<'buf> bebop::BebopDecode<'buf> for MultiLangKeywordVariant {
   }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RustKeywordFlags(pub u8);
 
 #[allow(non_upper_case_globals)]
@@ -5944,68 +6051,24 @@ impl RustKeywordFlags {
 impl bebop::BebopFlags for RustKeywordFlags {
   type Bits = u8;
   const ALL_BITS: Self::Bits = 7;
-  fn bits(self) -> Self::Bits {
-    self.0
-  }
-  fn from_bits_retain(bits: Self::Bits) -> Self {
-    Self(bits)
-  }
+  fn bits(self) -> Self::Bits { self.0 }
+  fn from_bits_retain(bits: Self::Bits) -> Self { Self(bits) }
 }
 
-impl ops::BitOr for RustKeywordFlags {
-  type Output = Self;
-  fn bitor(self, rhs: Self) -> Self {
-    Self(self.0 | rhs.0)
-  }
-}
-impl ops::BitOrAssign for RustKeywordFlags {
-  fn bitor_assign(&mut self, rhs: Self) {
-    self.0 |= rhs.0;
-  }
-}
-impl ops::BitAnd for RustKeywordFlags {
-  type Output = Self;
-  fn bitand(self, rhs: Self) -> Self {
-    Self(self.0 & rhs.0)
-  }
-}
-impl ops::BitAndAssign for RustKeywordFlags {
-  fn bitand_assign(&mut self, rhs: Self) {
-    self.0 &= rhs.0;
-  }
-}
-impl ops::BitXor for RustKeywordFlags {
-  type Output = Self;
-  fn bitxor(self, rhs: Self) -> Self {
-    Self(self.0 ^ rhs.0)
-  }
-}
-impl ops::BitXorAssign for RustKeywordFlags {
-  fn bitxor_assign(&mut self, rhs: Self) {
-    self.0 ^= rhs.0;
-  }
-}
-impl ops::Not for RustKeywordFlags {
-  type Output = Self;
-  fn not(self) -> Self {
-    Self(!self.0)
-  }
-}
-impl ops::Sub for RustKeywordFlags {
-  type Output = Self;
-  fn sub(self, rhs: Self) -> Self {
-    Self(self.0 & !rhs.0)
-  }
-}
+impl ops::BitOr for RustKeywordFlags { type Output = Self; fn bitor(self, rhs: Self) -> Self { Self(self.0 | rhs.0) } }
+impl ops::BitOrAssign for RustKeywordFlags { fn bitor_assign(&mut self, rhs: Self) { self.0 |= rhs.0; } }
+impl ops::BitAnd for RustKeywordFlags { type Output = Self; fn bitand(self, rhs: Self) -> Self { Self(self.0 & rhs.0) } }
+impl ops::BitAndAssign for RustKeywordFlags { fn bitand_assign(&mut self, rhs: Self) { self.0 &= rhs.0; } }
+impl ops::BitXor for RustKeywordFlags { type Output = Self; fn bitxor(self, rhs: Self) -> Self { Self(self.0 ^ rhs.0) } }
+impl ops::BitXorAssign for RustKeywordFlags { fn bitxor_assign(&mut self, rhs: Self) { self.0 ^= rhs.0; } }
+impl ops::Not for RustKeywordFlags { type Output = Self; fn not(self) -> Self { Self(!self.0) } }
+impl ops::Sub for RustKeywordFlags { type Output = Self; fn sub(self, rhs: Self) -> Self { Self(self.0 & !rhs.0) } }
 
 impl<'buf> bebop::BebopDecode<'buf> for RustKeywordFlags {
   #[inline(always)]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     let bits = reader.read_byte()?;
-    <Self as bebop::BebopFlags>::from_bits(bits).ok_or(bebop::DecodeError::InvalidFlags {
-      type_name: "RustKeywordFlags",
-      bits: bits as u64,
-    })
+    <Self as bebop::BebopFlags>::from_bits(bits).ok_or(bebop::DecodeError::InvalidFlags { type_name: "RustKeywordFlags", bits: bits as u64 })
   }
 }
 
@@ -6022,25 +6085,18 @@ impl bebop::BebopEncode for KeywordUnion {
     // @@bebop_insertion_point(encode_start:KeywordUnion)
     let pos = writer.reserve_message_length();
     match self {
-      Self::Mod(inner) => {
-        writer.write_byte(1);
-        inner.encode(writer);
-      }
-      Self::Match(inner) => {
-        writer.write_byte(2);
-        inner.encode(writer);
-      }
+      Self::Mod(inner) => { writer.write_byte(1); inner.encode(writer); }
+      Self::Match(inner) => { writer.write_byte(2); inner.encode(writer); }
     }
     writer.fill_message_length(pos);
     // @@bebop_insertion_point(encode_end:KeywordUnion)
   }
 
   fn encoded_size(&self) -> usize {
-    bebop::wire_size::WIRE_LEN_PREFIX_SIZE
-      + match self {
-        Self::Mod(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::Match(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-      }
+    bebop::wire_size::WIRE_LEN_PREFIX_SIZE + match self {
+      Self::Mod(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::Match(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+    }
   }
 }
 
@@ -6052,16 +6108,9 @@ impl<'buf> bebop::BebopDecode<'buf> for KeywordUnion {
     let start = reader.position();
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
-      1 => result::Result::Ok(Self::Mod(
-        Point::decode(reader).for_field("KeywordUnion", "mod")?,
-      )),
-      2 => result::Result::Ok(Self::Match(
-        Point::decode(reader).for_field("KeywordUnion", "match")?,
-      )),
-      _ => result::Result::Err(bebop::DecodeError::InvalidUnion {
-        type_name: "KeywordUnion",
-        discriminator,
-      }),
+      1 => result::Result::Ok(Self::Mod(Point::decode(reader).for_field("KeywordUnion", "mod")?)),
+      2 => result::Result::Ok(Self::Match(Point::decode(reader).for_field("KeywordUnion", "match")?)),
+      _ => result::Result::Err(bebop::DecodeError::InvalidUnion { type_name: "KeywordUnion", discriminator }),
     };
     // @@bebop_insertion_point(decode_end:KeywordUnion)
     value
@@ -6072,7 +6121,8 @@ impl KeywordUnion {
   // @@bebop_insertion_point(union_scope:KeywordUnion)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct KeywordFieldMessage<'buf> {
   pub r#type: option::Option<i32>,
   pub r#mod: option::Option<borrow::Cow<'buf, str>>,
@@ -6153,39 +6203,13 @@ impl<'buf> bebop::BebopDecode<'buf> for KeywordFieldMessage<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.r#type =
-            option::Option::Some(reader.read_i32().for_field("KeywordFieldMessage", "type")?)
-        }
-        2 => {
-          msg.r#mod = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("KeywordFieldMessage", "mod")?,
-          ))
-        }
-        3 => {
-          msg.self_ = option::Option::Some(
-            reader
-              .read_bool()
-              .for_field("KeywordFieldMessage", "self")?,
-          )
-        }
-        4 => {
-          msg.crate_ = option::Option::Some(
-            reader
-              .read_i32()
-              .for_field("KeywordFieldMessage", "crate")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "KeywordFieldMessage",
-            tag,
-          });
-        }
+        1 => msg.r#type = option::Option::Some(reader.read_i32().for_field("KeywordFieldMessage", "type")?),
+        2 => msg.r#mod = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("KeywordFieldMessage", "mod")?)),
+        3 => msg.self_ = option::Option::Some(reader.read_bool().for_field("KeywordFieldMessage", "self")?),
+        4 => msg.crate_ = option::Option::Some(reader.read_i32().for_field("KeywordFieldMessage", "crate")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "KeywordFieldMessage", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:KeywordFieldMessage)
@@ -6214,7 +6238,8 @@ impl<'buf> KeywordFieldMessage<'buf> {
 }
 
 /// Holds both a wire `guid` (runtime UUID) and a user-defined `Uuid` struct.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GuidAndUserUuidCollision {
   pub runtime_guid: bebop::Uuid,
   pub user_uuid: Uuid,
@@ -6223,11 +6248,11 @@ pub struct GuidAndUserUuidCollision {
 impl GuidAndUserUuidCollision {
   pub const FIXED_ENCODED_SIZE: usize = mem::size_of::<bebop::Uuid>() + Uuid::FIXED_ENCODED_SIZE;
 
-  pub fn new(runtime_guid: bebop::Uuid, user_uuid: Uuid) -> Self {
-    Self {
-      runtime_guid,
-      user_uuid,
-    }
+  pub fn new(
+    runtime_guid: bebop::Uuid,
+    user_uuid: Uuid,
+  ) -> Self {
+    Self { runtime_guid, user_uuid }
   }
 }
 
@@ -6248,15 +6273,10 @@ impl<'buf> bebop::BebopDecode<'buf> for GuidAndUserUuidCollision {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:GuidAndUserUuidCollision)
-    let runtime_guid = reader
-      .read_uuid()
-      .for_field("GuidAndUserUuidCollision", "runtime_guid")?;
+    let runtime_guid = reader.read_uuid().for_field("GuidAndUserUuidCollision", "runtime_guid")?;
     let user_uuid = Uuid::decode(reader).for_field("GuidAndUserUuidCollision", "user_uuid")?;
     // @@bebop_insertion_point(decode_end:GuidAndUserUuidCollision)
-    result::Result::Ok(GuidAndUserUuidCollision {
-      runtime_guid,
-      user_uuid,
-    })
+    result::Result::Ok(GuidAndUserUuidCollision { runtime_guid, user_uuid })
   }
 }
 
@@ -6264,7 +6284,8 @@ impl GuidAndUserUuidCollision {
   // @@bebop_insertion_point(struct_scope:GuidAndUserUuidCollision)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MapWithUserHashMapStruct<'buf> {
   pub items: option::Option<bebop::HashMap<borrow::Cow<'buf, str>, HashMap>>,
 }
@@ -6274,11 +6295,7 @@ pub type MapWithUserHashMapStructOwned = MapWithUserHashMapStruct<'static>;
 impl<'buf> MapWithUserHashMapStruct<'buf> {
   pub fn into_owned(self) -> MapWithUserHashMapStructOwned {
     MapWithUserHashMapStruct {
-      items: self.items.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v))
-          .collect()
-      }),
+      items: self.items.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v)).collect()),
     }
   }
 }
@@ -6294,10 +6311,7 @@ impl<'buf> bebop::BebopEncode for MapWithUserHashMapStruct<'buf> {
     // normally. This behavior should be revisited once the spec intent is clarified.
     if let option::Option::Some(ref v) = self.items {
       writer.write_tag(1);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _v.encode(_w);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _v.encode(_w); });
     }
     writer.write_end_marker();
     writer.fill_message_length(pos);
@@ -6307,9 +6321,7 @@ impl<'buf> bebop::BebopEncode for MapWithUserHashMapStruct<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.items {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len()) + _v.encoded_size()
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + _v.encoded_size()));
     }
     size
   }
@@ -6325,28 +6337,10 @@ impl<'buf> bebop::BebopDecode<'buf> for MapWithUserHashMapStruct<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.items = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  HashMap::decode(_r)?,
-                ))
-              })
-              .for_field("MapWithUserHashMapStruct", "items")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "MapWithUserHashMapStruct",
-            tag,
-          });
-        }
+        1 => msg.items = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, HashMap::decode(_r)?))).for_field("MapWithUserHashMapStruct", "items")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "MapWithUserHashMapStruct", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:MapWithUserHashMapStruct)
@@ -6355,10 +6349,7 @@ impl<'buf> bebop::BebopDecode<'buf> for MapWithUserHashMapStruct<'buf> {
 }
 
 impl<'buf> MapWithUserHashMapStruct<'buf> {
-  pub fn with_items(
-    mut self,
-    value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, HashMap)>,
-  ) -> Self {
+  pub fn with_items(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, HashMap)>) -> Self {
     self.items = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v)).collect());
     self
   }

--- a/plugins/rust/integration-tests/src/collision_types.rs
+++ b/plugins/rust/integration-tests/src/collision_types.rs
@@ -18,6 +18,7 @@ extern crate core;
 use alloc::{borrow, boxed, string, vec};
 use bebop_runtime as bebop;
 use bebop_runtime::serde;
+use bebop_runtime::DecodeContext as _;
 use core::convert::Into as _;
 use core::iter::{IntoIterator as _, Iterator as _};
 use core::{convert, default, iter, mem, ops, option, result};
@@ -56,8 +57,8 @@ impl<'buf> bebop::BebopDecode<'buf> for Point {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Point)
-    let x = reader.read_f32()?;
-    let y = reader.read_f32()?;
+    let x = reader.read_f32().for_field("Point", "x")?;
+    let y = reader.read_f32().for_field("Point", "y")?;
     // @@bebop_insertion_point(decode_end:Point)
     result::Result::Ok(Point { x, y })
   }
@@ -96,7 +97,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Uuid {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Uuid)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Uuid", "tag")?;
     // @@bebop_insertion_point(decode_end:Uuid)
     result::Result::Ok(Uuid { tag })
   }
@@ -135,7 +136,7 @@ impl<'buf> bebop::BebopDecode<'buf> for HashMap {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:HashMap)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("HashMap", "tag")?;
     // @@bebop_insertion_point(decode_end:HashMap)
     result::Result::Ok(HashMap { tag })
   }
@@ -174,7 +175,7 @@ impl<'buf> bebop::BebopDecode<'buf> for DecodeError {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:DecodeError)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("DecodeError", "tag")?;
     // @@bebop_insertion_point(decode_end:DecodeError)
     result::Result::Ok(DecodeError { tag })
   }
@@ -213,7 +214,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BebopReader {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BebopReader)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("BebopReader", "tag")?;
     // @@bebop_insertion_point(decode_end:BebopReader)
     result::Result::Ok(BebopReader { tag })
   }
@@ -252,7 +253,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BebopWriter {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BebopWriter)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("BebopWriter", "tag")?;
     // @@bebop_insertion_point(decode_end:BebopWriter)
     result::Result::Ok(BebopWriter { tag })
   }
@@ -291,7 +292,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BebopDecode {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BebopDecode)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("BebopDecode", "tag")?;
     // @@bebop_insertion_point(decode_end:BebopDecode)
     result::Result::Ok(BebopDecode { tag })
   }
@@ -330,7 +331,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BebopEncode {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BebopEncode)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("BebopEncode", "tag")?;
     // @@bebop_insertion_point(decode_end:BebopEncode)
     result::Result::Ok(BebopEncode { tag })
   }
@@ -369,7 +370,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BebopDuration {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BebopDuration)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("BebopDuration", "tag")?;
     // @@bebop_insertion_point(decode_end:BebopDuration)
     result::Result::Ok(BebopDuration { tag })
   }
@@ -408,7 +409,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BebopTimestamp {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BebopTimestamp)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("BebopTimestamp", "tag")?;
     // @@bebop_insertion_point(decode_end:BebopTimestamp)
     result::Result::Ok(BebopTimestamp { tag })
   }
@@ -447,7 +448,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BebopFlags {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BebopFlags)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("BebopFlags", "tag")?;
     // @@bebop_insertion_point(decode_end:BebopFlags)
     result::Result::Ok(BebopFlags { tag })
   }
@@ -486,7 +487,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BebopBytes {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BebopBytes)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("BebopBytes", "tag")?;
     // @@bebop_insertion_point(decode_end:BebopBytes)
     result::Result::Ok(BebopBytes { tag })
   }
@@ -525,7 +526,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Serde {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Serde)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Serde", "tag")?;
     // @@bebop_insertion_point(decode_end:Serde)
     result::Result::Ok(Serde { tag })
   }
@@ -564,7 +565,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Wire {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Wire)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Wire", "tag")?;
     // @@bebop_insertion_point(decode_end:Wire)
     result::Result::Ok(Wire { tag })
   }
@@ -603,7 +604,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Mod {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Mod)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Mod", "tag")?;
     // @@bebop_insertion_point(decode_end:Mod)
     result::Result::Ok(Mod { tag })
   }
@@ -642,7 +643,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Trait {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Trait)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Trait", "tag")?;
     // @@bebop_insertion_point(decode_end:Trait)
     result::Result::Ok(Trait { tag })
   }
@@ -681,7 +682,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Impl {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Impl)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Impl", "tag")?;
     // @@bebop_insertion_point(decode_end:Impl)
     result::Result::Ok(Impl { tag })
   }
@@ -720,7 +721,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Fn {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Fn)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Fn", "tag")?;
     // @@bebop_insertion_point(decode_end:Fn)
     result::Result::Ok(Fn { tag })
   }
@@ -759,7 +760,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Let {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Let)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Let", "tag")?;
     // @@bebop_insertion_point(decode_end:Let)
     result::Result::Ok(Let { tag })
   }
@@ -798,7 +799,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Use {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Use)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Use", "tag")?;
     // @@bebop_insertion_point(decode_end:Use)
     result::Result::Ok(Use { tag })
   }
@@ -837,7 +838,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Crate {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Crate)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Crate", "tag")?;
     // @@bebop_insertion_point(decode_end:Crate)
     result::Result::Ok(Crate { tag })
   }
@@ -876,7 +877,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Async {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Async)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Async", "tag")?;
     // @@bebop_insertion_point(decode_end:Async)
     result::Result::Ok(Async { tag })
   }
@@ -915,7 +916,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Await {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Await)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Await", "tag")?;
     // @@bebop_insertion_point(decode_end:Await)
     result::Result::Ok(Await { tag })
   }
@@ -954,7 +955,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Match {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Match)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Match", "tag")?;
     // @@bebop_insertion_point(decode_end:Match)
     result::Result::Ok(Match { tag })
   }
@@ -993,7 +994,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Where {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Where)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Where", "tag")?;
     // @@bebop_insertion_point(decode_end:Where)
     result::Result::Ok(Where { tag })
   }
@@ -1032,7 +1033,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Loop {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Loop)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Loop", "tag")?;
     // @@bebop_insertion_point(decode_end:Loop)
     result::Result::Ok(Loop { tag })
   }
@@ -1071,7 +1072,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Move {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Move)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Move", "tag")?;
     // @@bebop_insertion_point(decode_end:Move)
     result::Result::Ok(Move { tag })
   }
@@ -1110,7 +1111,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Ref {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Ref)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Ref", "tag")?;
     // @@bebop_insertion_point(decode_end:Ref)
     result::Result::Ok(Ref { tag })
   }
@@ -1149,7 +1150,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Dyn {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Dyn)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Dyn", "tag")?;
     // @@bebop_insertion_point(decode_end:Dyn)
     result::Result::Ok(Dyn { tag })
   }
@@ -1188,7 +1189,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Yield {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Yield)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Yield", "tag")?;
     // @@bebop_insertion_point(decode_end:Yield)
     result::Result::Ok(Yield { tag })
   }
@@ -1227,7 +1228,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Unsafe {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Unsafe)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Unsafe", "tag")?;
     // @@bebop_insertion_point(decode_end:Unsafe)
     result::Result::Ok(Unsafe { tag })
   }
@@ -1266,7 +1267,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Extern {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Extern)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Extern", "tag")?;
     // @@bebop_insertion_point(decode_end:Extern)
     result::Result::Ok(Extern { tag })
   }
@@ -1305,7 +1306,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Static {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Static)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Static", "tag")?;
     // @@bebop_insertion_point(decode_end:Static)
     result::Result::Ok(Static { tag })
   }
@@ -1344,7 +1345,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Virtual {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Virtual)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Virtual", "tag")?;
     // @@bebop_insertion_point(decode_end:Virtual)
     result::Result::Ok(Virtual { tag })
   }
@@ -1383,7 +1384,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Override {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Override)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Override", "tag")?;
     // @@bebop_insertion_point(decode_end:Override)
     result::Result::Ok(Override { tag })
   }
@@ -1422,7 +1423,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Final {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Final)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Final", "tag")?;
     // @@bebop_insertion_point(decode_end:Final)
     result::Result::Ok(Final { tag })
   }
@@ -1461,7 +1462,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Abstract {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Abstract)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Abstract", "tag")?;
     // @@bebop_insertion_point(decode_end:Abstract)
     result::Result::Ok(Abstract { tag })
   }
@@ -1500,7 +1501,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Self_ {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Self_)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Self_", "tag")?;
     // @@bebop_insertion_point(decode_end:Self_)
     result::Result::Ok(Self_ { tag })
   }
@@ -1539,7 +1540,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Super {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Super)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Super", "tag")?;
     // @@bebop_insertion_point(decode_end:Super)
     result::Result::Ok(Super { tag })
   }
@@ -1578,7 +1579,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Type {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Type)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Type", "tag")?;
     // @@bebop_insertion_point(decode_end:Type)
     result::Result::Ok(Type { tag })
   }
@@ -1617,7 +1618,7 @@ impl<'buf> bebop::BebopDecode<'buf> for For {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:For)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("For", "tag")?;
     // @@bebop_insertion_point(decode_end:For)
     result::Result::Ok(For { tag })
   }
@@ -1656,7 +1657,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Interface {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Interface)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Interface", "tag")?;
     // @@bebop_insertion_point(decode_end:Interface)
     result::Result::Ok(Interface { tag })
   }
@@ -1695,7 +1696,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Namespace {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Namespace)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Namespace", "tag")?;
     // @@bebop_insertion_point(decode_end:Namespace)
     result::Result::Ok(Namespace { tag })
   }
@@ -1734,7 +1735,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Default {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Default)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Default", "tag")?;
     // @@bebop_insertion_point(decode_end:Default)
     result::Result::Ok(Default { tag })
   }
@@ -1773,7 +1774,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Switch {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Switch)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Switch", "tag")?;
     // @@bebop_insertion_point(decode_end:Switch)
     result::Result::Ok(Switch { tag })
   }
@@ -1812,7 +1813,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Case {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Case)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Case", "tag")?;
     // @@bebop_insertion_point(decode_end:Case)
     result::Result::Ok(Case { tag })
   }
@@ -1851,7 +1852,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Goto {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Goto)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Goto", "tag")?;
     // @@bebop_insertion_point(decode_end:Goto)
     result::Result::Ok(Goto { tag })
   }
@@ -1890,7 +1891,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Volatile {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Volatile)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Volatile", "tag")?;
     // @@bebop_insertion_point(decode_end:Volatile)
     result::Result::Ok(Volatile { tag })
   }
@@ -1929,7 +1930,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Synchronized {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Synchronized)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Synchronized", "tag")?;
     // @@bebop_insertion_point(decode_end:Synchronized)
     result::Result::Ok(Synchronized { tag })
   }
@@ -1968,7 +1969,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Transient {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Transient)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Transient", "tag")?;
     // @@bebop_insertion_point(decode_end:Transient)
     result::Result::Ok(Transient { tag })
   }
@@ -2007,7 +2008,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Native {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Native)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Native", "tag")?;
     // @@bebop_insertion_point(decode_end:Native)
     result::Result::Ok(Native { tag })
   }
@@ -2046,7 +2047,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Throws {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Throws)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Throws", "tag")?;
     // @@bebop_insertion_point(decode_end:Throws)
     result::Result::Ok(Throws { tag })
   }
@@ -2085,7 +2086,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Strictfp {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Strictfp)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Strictfp", "tag")?;
     // @@bebop_insertion_point(decode_end:Strictfp)
     result::Result::Ok(Strictfp { tag })
   }
@@ -2124,7 +2125,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Assert {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Assert)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Assert", "tag")?;
     // @@bebop_insertion_point(decode_end:Assert)
     result::Result::Ok(Assert { tag })
   }
@@ -2163,7 +2164,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Sizeof {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Sizeof)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Sizeof", "tag")?;
     // @@bebop_insertion_point(decode_end:Sizeof)
     result::Result::Ok(Sizeof { tag })
   }
@@ -2202,7 +2203,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Typeof {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Typeof)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Typeof", "tag")?;
     // @@bebop_insertion_point(decode_end:Typeof)
     result::Result::Ok(Typeof { tag })
   }
@@ -2241,7 +2242,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Nullptr {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Nullptr)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Nullptr", "tag")?;
     // @@bebop_insertion_point(decode_end:Nullptr)
     result::Result::Ok(Nullptr { tag })
   }
@@ -2280,7 +2281,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Decltype {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Decltype)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Decltype", "tag")?;
     // @@bebop_insertion_point(decode_end:Decltype)
     result::Result::Ok(Decltype { tag })
   }
@@ -2319,7 +2320,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Constexpr {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Constexpr)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Constexpr", "tag")?;
     // @@bebop_insertion_point(decode_end:Constexpr)
     result::Result::Ok(Constexpr { tag })
   }
@@ -2358,7 +2359,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Noexcept {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Noexcept)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Noexcept", "tag")?;
     // @@bebop_insertion_point(decode_end:Noexcept)
     result::Result::Ok(Noexcept { tag })
   }
@@ -2397,7 +2398,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Template {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Template)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Template", "tag")?;
     // @@bebop_insertion_point(decode_end:Template)
     result::Result::Ok(Template { tag })
   }
@@ -2436,7 +2437,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Typename {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Typename)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Typename", "tag")?;
     // @@bebop_insertion_point(decode_end:Typename)
     result::Result::Ok(Typename { tag })
   }
@@ -2475,7 +2476,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Friend {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Friend)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Friend", "tag")?;
     // @@bebop_insertion_point(decode_end:Friend)
     result::Result::Ok(Friend { tag })
   }
@@ -2514,7 +2515,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Inline {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Inline)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Inline", "tag")?;
     // @@bebop_insertion_point(decode_end:Inline)
     result::Result::Ok(Inline { tag })
   }
@@ -2553,7 +2554,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Mutable {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Mutable)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Mutable", "tag")?;
     // @@bebop_insertion_point(decode_end:Mutable)
     result::Result::Ok(Mutable { tag })
   }
@@ -2592,7 +2593,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Explicit {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Explicit)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Explicit", "tag")?;
     // @@bebop_insertion_point(decode_end:Explicit)
     result::Result::Ok(Explicit { tag })
   }
@@ -2631,7 +2632,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Implicit {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Implicit)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Implicit", "tag")?;
     // @@bebop_insertion_point(decode_end:Implicit)
     result::Result::Ok(Implicit { tag })
   }
@@ -2670,7 +2671,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Operator {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Operator)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Operator", "tag")?;
     // @@bebop_insertion_point(decode_end:Operator)
     result::Result::Ok(Operator { tag })
   }
@@ -2709,7 +2710,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Delete {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Delete)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Delete", "tag")?;
     // @@bebop_insertion_point(decode_end:Delete)
     result::Result::Ok(Delete { tag })
   }
@@ -2748,7 +2749,7 @@ impl<'buf> bebop::BebopDecode<'buf> for New {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:New)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("New", "tag")?;
     // @@bebop_insertion_point(decode_end:New)
     result::Result::Ok(New { tag })
   }
@@ -2787,7 +2788,7 @@ impl<'buf> bebop::BebopDecode<'buf> for This {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:This)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("This", "tag")?;
     // @@bebop_insertion_point(decode_end:This)
     result::Result::Ok(This { tag })
   }
@@ -2826,7 +2827,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Extends {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Extends)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Extends", "tag")?;
     // @@bebop_insertion_point(decode_end:Extends)
     result::Result::Ok(Extends { tag })
   }
@@ -2865,7 +2866,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Implements {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Implements)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Implements", "tag")?;
     // @@bebop_insertion_point(decode_end:Implements)
     result::Result::Ok(Implements { tag })
   }
@@ -2904,7 +2905,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Instanceof {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Instanceof)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Instanceof", "tag")?;
     // @@bebop_insertion_point(decode_end:Instanceof)
     result::Result::Ok(Instanceof { tag })
   }
@@ -2943,7 +2944,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Boolean {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Boolean)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Boolean", "tag")?;
     // @@bebop_insertion_point(decode_end:Boolean)
     result::Result::Ok(Boolean { tag })
   }
@@ -2982,7 +2983,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Byte {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Byte)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Byte", "tag")?;
     // @@bebop_insertion_point(decode_end:Byte)
     result::Result::Ok(Byte { tag })
   }
@@ -3021,7 +3022,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Short {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Short)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Short", "tag")?;
     // @@bebop_insertion_point(decode_end:Short)
     result::Result::Ok(Short { tag })
   }
@@ -3060,7 +3061,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Long {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Long)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Long", "tag")?;
     // @@bebop_insertion_point(decode_end:Long)
     result::Result::Ok(Long { tag })
   }
@@ -3099,7 +3100,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Double {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Double)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Double", "tag")?;
     // @@bebop_insertion_point(decode_end:Double)
     result::Result::Ok(Double { tag })
   }
@@ -3138,7 +3139,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Float {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Float)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Float", "tag")?;
     // @@bebop_insertion_point(decode_end:Float)
     result::Result::Ok(Float { tag })
   }
@@ -3177,7 +3178,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Char {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Char)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Char", "tag")?;
     // @@bebop_insertion_point(decode_end:Char)
     result::Result::Ok(Char { tag })
   }
@@ -3216,7 +3217,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Void {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Void)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Void", "tag")?;
     // @@bebop_insertion_point(decode_end:Void)
     result::Result::Ok(Void { tag })
   }
@@ -3255,7 +3256,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Int {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Int)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Int", "tag")?;
     // @@bebop_insertion_point(decode_end:Int)
     result::Result::Ok(Int { tag })
   }
@@ -3294,7 +3295,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Var {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Var)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Var", "tag")?;
     // @@bebop_insertion_point(decode_end:Var)
     result::Result::Ok(Var { tag })
   }
@@ -3333,7 +3334,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Function {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Function)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Function", "tag")?;
     // @@bebop_insertion_point(decode_end:Function)
     result::Result::Ok(Function { tag })
   }
@@ -3372,7 +3373,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Debugger {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Debugger)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Debugger", "tag")?;
     // @@bebop_insertion_point(decode_end:Debugger)
     result::Result::Ok(Debugger { tag })
   }
@@ -3411,7 +3412,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Undefined {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Undefined)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Undefined", "tag")?;
     // @@bebop_insertion_point(decode_end:Undefined)
     result::Result::Ok(Undefined { tag })
   }
@@ -3450,7 +3451,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Declare {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Declare)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Declare", "tag")?;
     // @@bebop_insertion_point(decode_end:Declare)
     result::Result::Ok(Declare { tag })
   }
@@ -3489,7 +3490,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Require {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Require)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Require", "tag")?;
     // @@bebop_insertion_point(decode_end:Require)
     result::Result::Ok(Require { tag })
   }
@@ -3528,7 +3529,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Module {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Module)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Module", "tag")?;
     // @@bebop_insertion_point(decode_end:Module)
     result::Result::Ok(Module { tag })
   }
@@ -3567,7 +3568,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Global {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Global)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Global", "tag")?;
     // @@bebop_insertion_point(decode_end:Global)
     result::Result::Ok(Global { tag })
   }
@@ -3606,7 +3607,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Internal {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Internal)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Internal", "tag")?;
     // @@bebop_insertion_point(decode_end:Internal)
     result::Result::Ok(Internal { tag })
   }
@@ -3645,7 +3646,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Object {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Object)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Object", "tag")?;
     // @@bebop_insertion_point(decode_end:Object)
     result::Result::Ok(Object { tag })
   }
@@ -3684,7 +3685,7 @@ impl<'buf> bebop::BebopDecode<'buf> for String {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:String)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("String", "tag")?;
     // @@bebop_insertion_point(decode_end:String)
     result::Result::Ok(String { tag })
   }
@@ -3723,7 +3724,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Symbol {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Symbol)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Symbol", "tag")?;
     // @@bebop_insertion_point(decode_end:Symbol)
     result::Result::Ok(Symbol { tag })
   }
@@ -3762,7 +3763,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Bigint {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Bigint)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Bigint", "tag")?;
     // @@bebop_insertion_point(decode_end:Bigint)
     result::Result::Ok(Bigint { tag })
   }
@@ -3801,7 +3802,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Never {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Never)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Never", "tag")?;
     // @@bebop_insertion_point(decode_end:Never)
     result::Result::Ok(Never { tag })
   }
@@ -3840,7 +3841,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Unknown {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Unknown)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Unknown", "tag")?;
     // @@bebop_insertion_point(decode_end:Unknown)
     result::Result::Ok(Unknown { tag })
   }
@@ -3879,7 +3880,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Keyof {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Keyof)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Keyof", "tag")?;
     // @@bebop_insertion_point(decode_end:Keyof)
     result::Result::Ok(Keyof { tag })
   }
@@ -3918,7 +3919,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Infer {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Infer)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Infer", "tag")?;
     // @@bebop_insertion_point(decode_end:Infer)
     result::Result::Ok(Infer { tag })
   }
@@ -3957,7 +3958,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Satisfies {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Satisfies)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Satisfies", "tag")?;
     // @@bebop_insertion_point(decode_end:Satisfies)
     result::Result::Ok(Satisfies { tag })
   }
@@ -3996,7 +3997,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Out {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Out)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Out", "tag")?;
     // @@bebop_insertion_point(decode_end:Out)
     result::Result::Ok(Out { tag })
   }
@@ -4035,7 +4036,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Inout {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Inout)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Inout", "tag")?;
     // @@bebop_insertion_point(decode_end:Inout)
     result::Result::Ok(Inout { tag })
   }
@@ -4074,7 +4075,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Protocol {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Protocol)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Protocol", "tag")?;
     // @@bebop_insertion_point(decode_end:Protocol)
     result::Result::Ok(Protocol { tag })
   }
@@ -4113,7 +4114,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Subscript {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Subscript)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Subscript", "tag")?;
     // @@bebop_insertion_point(decode_end:Subscript)
     result::Result::Ok(Subscript { tag })
   }
@@ -4152,7 +4153,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Defer {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Defer)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Defer", "tag")?;
     // @@bebop_insertion_point(decode_end:Defer)
     result::Result::Ok(Defer { tag })
   }
@@ -4191,7 +4192,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Fallthrough {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Fallthrough)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Fallthrough", "tag")?;
     // @@bebop_insertion_point(decode_end:Fallthrough)
     result::Result::Ok(Fallthrough { tag })
   }
@@ -4230,7 +4231,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Repeat {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Repeat)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Repeat", "tag")?;
     // @@bebop_insertion_point(decode_end:Repeat)
     result::Result::Ok(Repeat { tag })
   }
@@ -4269,7 +4270,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Indirect {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Indirect)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Indirect", "tag")?;
     // @@bebop_insertion_point(decode_end:Indirect)
     result::Result::Ok(Indirect { tag })
   }
@@ -4308,7 +4309,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Nonisolated {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Nonisolated)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Nonisolated", "tag")?;
     // @@bebop_insertion_point(decode_end:Nonisolated)
     result::Result::Ok(Nonisolated { tag })
   }
@@ -4347,7 +4348,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Lazy {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Lazy)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Lazy", "tag")?;
     // @@bebop_insertion_point(decode_end:Lazy)
     result::Result::Ok(Lazy { tag })
   }
@@ -4386,7 +4387,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Weak {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Weak)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Weak", "tag")?;
     // @@bebop_insertion_point(decode_end:Weak)
     result::Result::Ok(Weak { tag })
   }
@@ -4425,7 +4426,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Unowned {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Unowned)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Unowned", "tag")?;
     // @@bebop_insertion_point(decode_end:Unowned)
     result::Result::Ok(Unowned { tag })
   }
@@ -4464,7 +4465,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Convenience {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Convenience)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Convenience", "tag")?;
     // @@bebop_insertion_point(decode_end:Convenience)
     result::Result::Ok(Convenience { tag })
   }
@@ -4503,7 +4504,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Required {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Required)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Required", "tag")?;
     // @@bebop_insertion_point(decode_end:Required)
     result::Result::Ok(Required { tag })
   }
@@ -4542,7 +4543,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Optional {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Optional)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Optional", "tag")?;
     // @@bebop_insertion_point(decode_end:Optional)
     result::Result::Ok(Optional { tag })
   }
@@ -4581,7 +4582,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Rethrows {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Rethrows)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Rethrows", "tag")?;
     // @@bebop_insertion_point(decode_end:Rethrows)
     result::Result::Ok(Rethrows { tag })
   }
@@ -4620,7 +4621,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Try {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Try)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Try", "tag")?;
     // @@bebop_insertion_point(decode_end:Try)
     result::Result::Ok(Try { tag })
   }
@@ -4659,7 +4660,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Catch {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Catch)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Catch", "tag")?;
     // @@bebop_insertion_point(decode_end:Catch)
     result::Result::Ok(Catch { tag })
   }
@@ -4698,7 +4699,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Throw {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Throw)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Throw", "tag")?;
     // @@bebop_insertion_point(decode_end:Throw)
     result::Result::Ok(Throw { tag })
   }
@@ -4737,7 +4738,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Guard {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Guard)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Guard", "tag")?;
     // @@bebop_insertion_point(decode_end:Guard)
     result::Result::Ok(Guard { tag })
   }
@@ -4776,7 +4777,7 @@ impl<'buf> bebop::BebopDecode<'buf> for In {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:In)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("In", "tag")?;
     // @@bebop_insertion_point(decode_end:In)
     result::Result::Ok(In { tag })
   }
@@ -4815,7 +4816,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Is {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Is)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Is", "tag")?;
     // @@bebop_insertion_point(decode_end:Is)
     result::Result::Ok(Is { tag })
   }
@@ -4854,7 +4855,7 @@ impl<'buf> bebop::BebopDecode<'buf> for As {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:As)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("As", "tag")?;
     // @@bebop_insertion_point(decode_end:As)
     result::Result::Ok(As { tag })
   }
@@ -4893,7 +4894,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Select {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Select)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Select", "tag")?;
     // @@bebop_insertion_point(decode_end:Select)
     result::Result::Ok(Select { tag })
   }
@@ -4932,7 +4933,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Event {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Event)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Event", "tag")?;
     // @@bebop_insertion_point(decode_end:Event)
     result::Result::Ok(Event { tag })
   }
@@ -4971,7 +4972,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Delegate {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Delegate)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Delegate", "tag")?;
     // @@bebop_insertion_point(decode_end:Delegate)
     result::Result::Ok(Delegate { tag })
   }
@@ -5010,7 +5011,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Checked {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Checked)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Checked", "tag")?;
     // @@bebop_insertion_point(decode_end:Checked)
     result::Result::Ok(Checked { tag })
   }
@@ -5049,7 +5050,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Unchecked {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Unchecked)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Unchecked", "tag")?;
     // @@bebop_insertion_point(decode_end:Unchecked)
     result::Result::Ok(Unchecked { tag })
   }
@@ -5088,7 +5089,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Stackalloc {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Stackalloc)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Stackalloc", "tag")?;
     // @@bebop_insertion_point(decode_end:Stackalloc)
     result::Result::Ok(Stackalloc { tag })
   }
@@ -5127,7 +5128,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Params {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Params)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Params", "tag")?;
     // @@bebop_insertion_point(decode_end:Params)
     result::Result::Ok(Params { tag })
   }
@@ -5166,7 +5167,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Lock {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Lock)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Lock", "tag")?;
     // @@bebop_insertion_point(decode_end:Lock)
     result::Result::Ok(Lock { tag })
   }
@@ -5205,7 +5206,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Nameof {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Nameof)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Nameof", "tag")?;
     // @@bebop_insertion_point(decode_end:Nameof)
     result::Result::Ok(Nameof { tag })
   }
@@ -5244,7 +5245,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Sbyte {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Sbyte)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Sbyte", "tag")?;
     // @@bebop_insertion_point(decode_end:Sbyte)
     result::Result::Ok(Sbyte { tag })
   }
@@ -5283,7 +5284,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Ushort {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Ushort)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Ushort", "tag")?;
     // @@bebop_insertion_point(decode_end:Ushort)
     result::Result::Ok(Ushort { tag })
   }
@@ -5322,7 +5323,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Uint {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Uint)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Uint", "tag")?;
     // @@bebop_insertion_point(decode_end:Uint)
     result::Result::Ok(Uint { tag })
   }
@@ -5361,7 +5362,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Ulong {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Ulong)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Ulong", "tag")?;
     // @@bebop_insertion_point(decode_end:Ulong)
     result::Result::Ok(Ulong { tag })
   }
@@ -5400,7 +5401,7 @@ impl<'buf> bebop::BebopDecode<'buf> for When {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:When)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("When", "tag")?;
     // @@bebop_insertion_point(decode_end:When)
     result::Result::Ok(When { tag })
   }
@@ -5439,7 +5440,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Init {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Init)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Init", "tag")?;
     // @@bebop_insertion_point(decode_end:Init)
     result::Result::Ok(Init { tag })
   }
@@ -5478,7 +5479,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Deinit {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Deinit)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Deinit", "tag")?;
     // @@bebop_insertion_point(decode_end:Deinit)
     result::Result::Ok(Deinit { tag })
   }
@@ -5517,7 +5518,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Get {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Get)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Get", "tag")?;
     // @@bebop_insertion_point(decode_end:Get)
     result::Result::Ok(Get { tag })
   }
@@ -5556,7 +5557,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Set {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Set)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Set", "tag")?;
     // @@bebop_insertion_point(decode_end:Set)
     result::Result::Ok(Set { tag })
   }
@@ -5595,7 +5596,7 @@ impl<'buf> bebop::BebopDecode<'buf> for WillSet {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:WillSet)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("WillSet", "tag")?;
     // @@bebop_insertion_point(decode_end:WillSet)
     result::Result::Ok(WillSet { tag })
   }
@@ -5634,7 +5635,7 @@ impl<'buf> bebop::BebopDecode<'buf> for DidSet {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:DidSet)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("DidSet", "tag")?;
     // @@bebop_insertion_point(decode_end:DidSet)
     result::Result::Ok(DidSet { tag })
   }
@@ -5673,7 +5674,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Associatedtype {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Associatedtype)
-    let tag = reader.read_i32()?;
+    let tag = reader.read_i32().for_field("Associatedtype", "tag")?;
     // @@bebop_insertion_point(decode_end:Associatedtype)
     result::Result::Ok(Associatedtype { tag })
   }
@@ -5805,24 +5806,24 @@ impl<'buf> bebop::BebopDecode<'buf> for RustKeywordFields {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:RustKeywordFields)
-    let r#type = reader.read_i32()?;
-    let r#mod = reader.read_i32()?;
-    let self_ = reader.read_i32()?;
-    let super_ = reader.read_i32()?;
-    let crate_ = reader.read_i32()?;
-    let r#match = reader.read_i32()?;
-    let r#where = reader.read_i32()?;
-    let r#loop = reader.read_i32()?;
-    let r#move = reader.read_i32()?;
-    let r#ref = reader.read_i32()?;
-    let r#dyn = reader.read_i32()?;
-    let r#use = reader.read_i32()?;
-    let r#let = reader.read_i32()?;
-    let r#fn = reader.read_i32()?;
-    let r#as = reader.read_i32()?;
-    let r#in = reader.read_i32()?;
-    let is = reader.read_i32()?;
-    let r#try = reader.read_i32()?;
+    let r#type = reader.read_i32().for_field("RustKeywordFields", "type")?;
+    let r#mod = reader.read_i32().for_field("RustKeywordFields", "mod")?;
+    let self_ = reader.read_i32().for_field("RustKeywordFields", "self_")?;
+    let super_ = reader.read_i32().for_field("RustKeywordFields", "super_")?;
+    let crate_ = reader.read_i32().for_field("RustKeywordFields", "crate_")?;
+    let r#match = reader.read_i32().for_field("RustKeywordFields", "match")?;
+    let r#where = reader.read_i32().for_field("RustKeywordFields", "where")?;
+    let r#loop = reader.read_i32().for_field("RustKeywordFields", "loop")?;
+    let r#move = reader.read_i32().for_field("RustKeywordFields", "move")?;
+    let r#ref = reader.read_i32().for_field("RustKeywordFields", "ref")?;
+    let r#dyn = reader.read_i32().for_field("RustKeywordFields", "dyn")?;
+    let r#use = reader.read_i32().for_field("RustKeywordFields", "use")?;
+    let r#let = reader.read_i32().for_field("RustKeywordFields", "let")?;
+    let r#fn = reader.read_i32().for_field("RustKeywordFields", "fn")?;
+    let r#as = reader.read_i32().for_field("RustKeywordFields", "as")?;
+    let r#in = reader.read_i32().for_field("RustKeywordFields", "in")?;
+    let is = reader.read_i32().for_field("RustKeywordFields", "is")?;
+    let r#try = reader.read_i32().for_field("RustKeywordFields", "try")?;
     // @@bebop_insertion_point(decode_end:RustKeywordFields)
     result::Result::Ok(RustKeywordFields {
       r#type,
@@ -6051,8 +6052,12 @@ impl<'buf> bebop::BebopDecode<'buf> for KeywordUnion {
     let start = reader.position();
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
-      1 => result::Result::Ok(Self::Mod(Point::decode(reader)?)),
-      2 => result::Result::Ok(Self::Match(Point::decode(reader)?)),
+      1 => result::Result::Ok(Self::Mod(
+        Point::decode(reader).for_field("KeywordUnion", "mod")?,
+      )),
+      2 => result::Result::Ok(Self::Match(
+        Point::decode(reader).for_field("KeywordUnion", "match")?,
+      )),
       _ => result::Result::Err(bebop::DecodeError::InvalidUnion {
         type_name: "KeywordUnion",
         discriminator,
@@ -6152,10 +6157,29 @@ impl<'buf> bebop::BebopDecode<'buf> for KeywordFieldMessage<'buf> {
         break;
       }
       match tag {
-        1 => msg.r#type = option::Option::Some(reader.read_i32()?),
-        2 => msg.r#mod = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.self_ = option::Option::Some(reader.read_bool()?),
-        4 => msg.crate_ = option::Option::Some(reader.read_i32()?),
+        1 => {
+          msg.r#type =
+            option::Option::Some(reader.read_i32().for_field("KeywordFieldMessage", "type")?)
+        }
+        2 => {
+          msg.r#mod = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("KeywordFieldMessage", "mod")?,
+          ))
+        }
+        3 => {
+          msg.self_ = option::Option::Some(
+            reader
+              .read_bool()
+              .for_field("KeywordFieldMessage", "self_")?,
+          )
+        }
+        4 => {
+          msg.crate_ = option::Option::Some(
+            reader
+              .read_i32()
+              .for_field("KeywordFieldMessage", "crate_")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "KeywordFieldMessage",
@@ -6224,8 +6248,10 @@ impl<'buf> bebop::BebopDecode<'buf> for GuidAndUserUuidCollision {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:GuidAndUserUuidCollision)
-    let runtime_guid = reader.read_uuid()?;
-    let user_uuid = Uuid::decode(reader)?;
+    let runtime_guid = reader
+      .read_uuid()
+      .for_field("GuidAndUserUuidCollision", "runtime_guid")?;
+    let user_uuid = Uuid::decode(reader).for_field("GuidAndUserUuidCollision", "user_uuid")?;
     // @@bebop_insertion_point(decode_end:GuidAndUserUuidCollision)
     result::Result::Ok(GuidAndUserUuidCollision {
       runtime_guid,
@@ -6304,12 +6330,16 @@ impl<'buf> bebop::BebopDecode<'buf> for MapWithUserHashMapStruct<'buf> {
       }
       match tag {
         1 => {
-          msg.items = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              HashMap::decode(_r)?,
-            ))
-          })?)
+          msg.items = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  HashMap::decode(_r)?,
+                ))
+              })
+              .for_field("MapWithUserHashMapStruct", "items")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {

--- a/plugins/rust/integration-tests/src/test_types.rs
+++ b/plugins/rust/integration-tests/src/test_types.rs
@@ -18,6 +18,7 @@ extern crate core;
 use alloc::{borrow, boxed, string, vec};
 use bebop_runtime as bebop;
 use bebop_runtime::serde;
+use bebop_runtime::DecodeContext as _;
 use core::convert::Into as _;
 use core::iter::{IntoIterator as _, Iterator as _};
 use core::{convert, default, iter, mem, ops, option, result};
@@ -242,8 +243,8 @@ impl<'buf> bebop::BebopDecode<'buf> for Point {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Point)
-    let x = reader.read_f32()?;
-    let y = reader.read_f32()?;
+    let x = reader.read_f32().for_field("Point", "x")?;
+    let y = reader.read_f32().for_field("Point", "y")?;
     // @@bebop_insertion_point(decode_end:Point)
     result::Result::Ok(Point { x, y })
   }
@@ -292,9 +293,9 @@ impl<'buf> bebop::BebopDecode<'buf> for Pixel {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Pixel)
-    let position = Point::decode(reader)?;
-    let color = Color::decode(reader)?;
-    let alpha = reader.read_byte()?;
+    let position = Point::decode(reader).for_field("Pixel", "position")?;
+    let color = Color::decode(reader).for_field("Pixel", "color")?;
+    let alpha = reader.read_byte().for_field("Pixel", "alpha")?;
     // @@bebop_insertion_point(decode_end:Pixel)
     result::Result::Ok(Pixel {
       position,
@@ -353,8 +354,8 @@ impl<'buf> bebop::BebopDecode<'buf> for Person<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Person)
-    let name = borrow::Cow::Borrowed(reader.read_str()?);
-    let age = reader.read_u32()?;
+    let name = borrow::Cow::Borrowed(reader.read_str().for_field("Person", "name")?);
+    let age = reader.read_u32().for_field("Person", "age")?;
     // @@bebop_insertion_point(decode_end:Person)
     result::Result::Ok(Person { name, age })
   }
@@ -409,8 +410,12 @@ impl<'buf> bebop::BebopDecode<'buf> for BinaryPayload<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BinaryPayload)
-    let tag = reader.read_u32()?;
-    let data = bebop::BebopBytes::borrowed(reader.read_byte_slice()?);
+    let tag = reader.read_u32().for_field("BinaryPayload", "tag")?;
+    let data = bebop::BebopBytes::borrowed(
+      reader
+        .read_byte_slice()
+        .for_field("BinaryPayload", "data")?,
+    );
     // @@bebop_insertion_point(decode_end:BinaryPayload)
     result::Result::Ok(BinaryPayload { tag, data })
   }
@@ -553,24 +558,44 @@ impl<'buf> bebop::BebopDecode<'buf> for UserProfile<'buf> {
         break;
       }
       match tag {
-        1 => msg.display_name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.email = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.age = option::Option::Some(reader.read_u32()?),
-        4 => msg.active = option::Option::Some(reader.read_bool()?),
+        1 => {
+          msg.display_name = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("UserProfile", "display_name")?,
+          ))
+        }
+        2 => {
+          msg.email = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("UserProfile", "email")?,
+          ))
+        }
+        3 => msg.age = option::Option::Some(reader.read_u32().for_field("UserProfile", "age")?),
+        4 => {
+          msg.active = option::Option::Some(reader.read_bool().for_field("UserProfile", "active")?)
+        }
         5 => {
           msg.tags = option::Option::Some(
-            reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))?,
+            reader
+              .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
+              .for_field("UserProfile", "tags")?,
           )
         }
         6 => {
-          msg.metadata = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-            ))
-          })?)
+          msg.metadata = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                ))
+              })
+              .for_field("UserProfile", "metadata")?,
+          )
         }
-        7 => msg.permissions = option::Option::Some(Permissions::decode(reader)?),
+        7 => {
+          msg.permissions = option::Option::Some(
+            Permissions::decode(reader).for_field("UserProfile", "permissions")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "UserProfile",
@@ -716,10 +741,22 @@ impl<'buf> bebop::BebopDecode<'buf> for DrawCommand<'buf> {
         break;
       }
       match tag {
-        1 => msg.target = option::Option::Some(Point::decode(reader)?),
-        2 => msg.color = option::Option::Some(Color::decode(reader)?),
-        3 => msg.label = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        4 => msg.thickness = option::Option::Some(reader.read_f32()?),
+        1 => {
+          msg.target =
+            option::Option::Some(Point::decode(reader).for_field("DrawCommand", "target")?)
+        }
+        2 => {
+          msg.color = option::Option::Some(Color::decode(reader).for_field("DrawCommand", "color")?)
+        }
+        3 => {
+          msg.label = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("DrawCommand", "label")?,
+          ))
+        }
+        4 => {
+          msg.thickness =
+            option::Option::Some(reader.read_f32().for_field("DrawCommand", "thickness")?)
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "DrawCommand",
@@ -798,8 +835,8 @@ impl<'buf> bebop::BebopDecode<'buf> for TextLabel<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TextLabel)
-    let position = Point::decode(reader)?;
-    let text = borrow::Cow::Borrowed(reader.read_str()?);
+    let position = Point::decode(reader).for_field("TextLabel", "position")?;
+    let text = borrow::Cow::Borrowed(reader.read_str().for_field("TextLabel", "text")?);
     // @@bebop_insertion_point(decode_end:TextLabel)
     result::Result::Ok(TextLabel { position, text })
   }
@@ -879,9 +916,15 @@ impl<'buf> bebop::BebopDecode<'buf> for Shape<'buf> {
     let start = reader.position();
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
-      1 => result::Result::Ok(Self::Point(Point::decode(reader)?)),
-      2 => result::Result::Ok(Self::Pixel(Pixel::decode(reader)?)),
-      3 => result::Result::Ok(Self::Label(TextLabel::decode(reader)?)),
+      1 => result::Result::Ok(Self::Point(
+        Point::decode(reader).for_field("Shape", "point")?,
+      )),
+      2 => result::Result::Ok(Self::Pixel(
+        Pixel::decode(reader).for_field("Shape", "pixel")?,
+      )),
+      3 => result::Result::Ok(Self::Label(
+        TextLabel::decode(reader).for_field("Shape", "label")?,
+      )),
       // @@bebop_insertion_point(decode_switch:Shape)
       _ => {
         let remaining = length - (reader.position() - start);
@@ -942,8 +985,12 @@ impl<'buf> bebop::BebopDecode<'buf> for StrictShape {
     let start = reader.position();
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
-      1 => result::Result::Ok(Self::Point(Point::decode(reader)?)),
-      2 => result::Result::Ok(Self::Pixel(Pixel::decode(reader)?)),
+      1 => result::Result::Ok(Self::Point(
+        Point::decode(reader).for_field("StrictShape", "point")?,
+      )),
+      2 => result::Result::Ok(Self::Pixel(
+        Pixel::decode(reader).for_field("StrictShape", "pixel")?,
+      )),
       _ => result::Result::Err(bebop::DecodeError::InvalidUnion {
         type_name: "StrictShape",
         discriminator,
@@ -1095,8 +1142,14 @@ impl<'buf> bebop::BebopDecode<'buf> for StrictConfig<'buf> {
         break;
       }
       match tag {
-        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.value = option::Option::Some(reader.read_u32()?),
+        1 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("StrictConfig", "name")?,
+          ))
+        }
+        2 => {
+          msg.value = option::Option::Some(reader.read_u32().for_field("StrictConfig", "value")?)
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "StrictConfig",
@@ -1187,8 +1240,12 @@ impl<'buf> bebop::BebopDecode<'buf> for FlexConfig<'buf> {
         break;
       }
       match tag {
-        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.value = option::Option::Some(reader.read_u32()?),
+        1 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("FlexConfig", "name")?,
+          ))
+        }
+        2 => msg.value = option::Option::Some(reader.read_u32().for_field("FlexConfig", "value")?),
         _ => {
           reader.skip(end - reader.position())?;
         }
@@ -1318,7 +1375,9 @@ impl<'buf> bebop::BebopDecode<'buf> for Matrix2x2 {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Matrix2x2)
-    let values = reader.read_fixed_array::<f32, 4>()?;
+    let values = reader
+      .read_fixed_array::<f32, 4>()
+      .for_field("Matrix2x2", "values")?;
     // @@bebop_insertion_point(decode_end:Matrix2x2)
     result::Result::Ok(Matrix2x2 { values })
   }
@@ -1361,8 +1420,12 @@ impl<'buf> bebop::BebopDecode<'buf> for HalfPrecisionScalars {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:HalfPrecisionScalars)
-    let f16_val = reader.read_f16()?;
-    let bf16_val = reader.read_bf16()?;
+    let f16_val = reader
+      .read_f16()
+      .for_field("HalfPrecisionScalars", "f16_val")?;
+    let bf16_val = reader
+      .read_bf16()
+      .for_field("HalfPrecisionScalars", "bf16_val")?;
     // @@bebop_insertion_point(decode_end:HalfPrecisionScalars)
     result::Result::Ok(HalfPrecisionScalars { f16_val, bf16_val })
   }
@@ -1435,10 +1498,18 @@ impl<'buf> bebop::BebopDecode<'buf> for HalfPrecisionArrays<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:HalfPrecisionArrays)
-    let f16_dynamic = reader.read_scalar_array::<bebop::f16>()?;
-    let bf16_dynamic = reader.read_scalar_array::<bebop::bf16>()?;
-    let f16_fixed = reader.read_fixed_array::<bebop::f16, 4>()?;
-    let bf16_fixed = reader.read_fixed_array::<bebop::bf16, 4>()?;
+    let f16_dynamic = reader
+      .read_scalar_array::<bebop::f16>()
+      .for_field("HalfPrecisionArrays", "f16_dynamic")?;
+    let bf16_dynamic = reader
+      .read_scalar_array::<bebop::bf16>()
+      .for_field("HalfPrecisionArrays", "bf16_dynamic")?;
+    let f16_fixed = reader
+      .read_fixed_array::<bebop::f16, 4>()
+      .for_field("HalfPrecisionArrays", "f16_fixed")?;
+    let bf16_fixed = reader
+      .read_fixed_array::<bebop::bf16, 4>()
+      .for_field("HalfPrecisionArrays", "bf16_fixed")?;
     // @@bebop_insertion_point(decode_end:HalfPrecisionArrays)
     result::Result::Ok(HalfPrecisionArrays {
       f16_dynamic,
@@ -1540,10 +1611,34 @@ impl<'buf> bebop::BebopDecode<'buf> for HalfPrecisionMessage<'buf> {
         break;
       }
       match tag {
-        1 => msg.f16_val = option::Option::Some(reader.read_f16()?),
-        2 => msg.bf16_val = option::Option::Some(reader.read_bf16()?),
-        3 => msg.f16_arr = option::Option::Some(reader.read_scalar_array::<bebop::f16>()?),
-        4 => msg.bf16_arr = option::Option::Some(reader.read_scalar_array::<bebop::bf16>()?),
+        1 => {
+          msg.f16_val = option::Option::Some(
+            reader
+              .read_f16()
+              .for_field("HalfPrecisionMessage", "f16_val")?,
+          )
+        }
+        2 => {
+          msg.bf16_val = option::Option::Some(
+            reader
+              .read_bf16()
+              .for_field("HalfPrecisionMessage", "bf16_val")?,
+          )
+        }
+        3 => {
+          msg.f16_arr = option::Option::Some(
+            reader
+              .read_scalar_array::<bebop::f16>()
+              .for_field("HalfPrecisionMessage", "f16_arr")?,
+          )
+        }
+        4 => {
+          msg.bf16_arr = option::Option::Some(
+            reader
+              .read_scalar_array::<bebop::bf16>()
+              .for_field("HalfPrecisionMessage", "bf16_arr")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "HalfPrecisionMessage",
@@ -1649,10 +1744,10 @@ impl<'buf> bebop::BebopDecode<'buf> for Address<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Address)
-    let street = borrow::Cow::Borrowed(reader.read_str()?);
-    let city = borrow::Cow::Borrowed(reader.read_str()?);
-    let country = borrow::Cow::Borrowed(reader.read_str()?);
-    let zip_code = borrow::Cow::Borrowed(reader.read_str()?);
+    let street = borrow::Cow::Borrowed(reader.read_str().for_field("Address", "street")?);
+    let city = borrow::Cow::Borrowed(reader.read_str().for_field("Address", "city")?);
+    let country = borrow::Cow::Borrowed(reader.read_str().for_field("Address", "country")?);
+    let zip_code = borrow::Cow::Borrowed(reader.read_str().for_field("Address", "zip_code")?);
     // @@bebop_insertion_point(decode_end:Address)
     result::Result::Ok(Address {
       street,
@@ -1745,9 +1840,22 @@ impl<'buf> bebop::BebopDecode<'buf> for Scene<'buf> {
         break;
       }
       match tag {
-        1 => msg.shapes = option::Option::Some(reader.read_array(|_r| Shape::decode(_r))?),
-        2 => msg.background = option::Option::Some(Color::decode(reader)?),
-        3 => msg.title = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        1 => {
+          msg.shapes = option::Option::Some(
+            reader
+              .read_array(|_r| Shape::decode(_r))
+              .for_field("Scene", "shapes")?,
+          )
+        }
+        2 => {
+          msg.background =
+            option::Option::Some(Color::decode(reader).for_field("Scene", "background")?)
+        }
+        3 => {
+          msg.title = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("Scene", "title")?,
+          ))
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "Scene",
@@ -1853,14 +1961,22 @@ impl<'buf> bebop::BebopDecode<'buf> for Inventory<'buf> {
       }
       match tag {
         1 => {
-          msg.items = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              _r.read_u32()?,
-            ))
-          })?)
+          msg.items = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  _r.read_u32()?,
+                ))
+              })
+              .for_field("Inventory", "items")?,
+          )
         }
-        2 => msg.label = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        2 => {
+          msg.label = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("Inventory", "label")?,
+          ))
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "Inventory",
@@ -1948,7 +2064,13 @@ impl<'buf> bebop::BebopDecode<'buf> for EmptyMessage<'buf> {
         break;
       }
       match tag {
-        1 => msg.unused_field = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        1 => {
+          msg.unused_field = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("EmptyMessage", "unused_field")?,
+          ))
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "EmptyMessage",
@@ -2018,8 +2140,10 @@ impl<'buf> bebop::BebopDecode<'buf> for TimestampedEvent<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TimestampedEvent)
-    let when = reader.read_timestamp()?;
-    let what = borrow::Cow::Borrowed(reader.read_str()?);
+    let when = reader
+      .read_timestamp()
+      .for_field("TimestampedEvent", "when")?;
+    let what = borrow::Cow::Borrowed(reader.read_str().for_field("TimestampedEvent", "what")?);
     // @@bebop_insertion_point(decode_end:TimestampedEvent)
     result::Result::Ok(TimestampedEvent { when, what })
   }
@@ -2104,9 +2228,25 @@ impl<'buf> bebop::BebopDecode<'buf> for ScheduleEntry<'buf> {
         break;
       }
       match tag {
-        1 => msg.start = option::Option::Some(reader.read_timestamp()?),
-        2 => msg.duration = option::Option::Some(reader.read_duration()?),
-        3 => msg.label = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        1 => {
+          msg.start = option::Option::Some(
+            reader
+              .read_timestamp()
+              .for_field("ScheduleEntry", "start")?,
+          )
+        }
+        2 => {
+          msg.duration = option::Option::Some(
+            reader
+              .read_duration()
+              .for_field("ScheduleEntry", "duration")?,
+          )
+        }
+        3 => {
+          msg.label = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("ScheduleEntry", "label")?,
+          ))
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "ScheduleEntry",
@@ -2176,7 +2316,7 @@ impl<'buf> bebop::BebopDecode<'buf> for ForwardRefA<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:ForwardRefA)
-    let b = ForwardRefB::decode(reader)?;
+    let b = ForwardRefB::decode(reader).for_field("ForwardRefA", "b")?;
     // @@bebop_insertion_point(decode_end:ForwardRefA)
     result::Result::Ok(ForwardRefA { b })
   }
@@ -2226,7 +2366,7 @@ impl<'buf> bebop::BebopDecode<'buf> for ForwardRefB<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:ForwardRefB)
-    let value = borrow::Cow::Borrowed(reader.read_str()?);
+    let value = borrow::Cow::Borrowed(reader.read_str().for_field("ForwardRefB", "value")?);
     // @@bebop_insertion_point(decode_end:ForwardRefB)
     result::Result::Ok(ForwardRefB { value })
   }
@@ -2315,9 +2455,27 @@ impl<'buf> bebop::BebopDecode<'buf> for DeprecatedFieldsMessage<'buf> {
         break;
       }
       match tag {
-        1 => msg.current_name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.legacy_name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.legacy_enabled = option::Option::Some(reader.read_bool()?),
+        1 => {
+          msg.current_name = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("DeprecatedFieldsMessage", "current_name")?,
+          ))
+        }
+        2 => {
+          msg.legacy_name = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("DeprecatedFieldsMessage", "legacy_name")?,
+          ))
+        }
+        3 => {
+          msg.legacy_enabled = option::Option::Some(
+            reader
+              .read_bool()
+              .for_field("DeprecatedFieldsMessage", "legacy_enabled")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "DeprecatedFieldsMessage",
@@ -2428,16 +2586,22 @@ impl<'buf> bebop::BebopDecode<'buf> for IntegerKeyMaps<'buf> {
       }
       match tag {
         1 => {
-          msg.labels_by_id = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              _r.read_u32()?,
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-            ))
-          })?)
+          msg.labels_by_id = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  _r.read_u32()?,
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                ))
+              })
+              .for_field("IntegerKeyMaps", "labels_by_id")?,
+          )
         }
         2 => {
           msg.flags_by_id = option::Option::Some(
-            reader.read_map(|_r| result::Result::Ok((_r.read_i64()?, _r.read_bool()?)))?,
+            reader
+              .read_map(|_r| result::Result::Ok((_r.read_i64()?, _r.read_bool()?)))
+              .for_field("IntegerKeyMaps", "flags_by_id")?,
           )
         }
         tag => {
@@ -2510,7 +2674,7 @@ impl<'buf> bebop::BebopDecode<'buf> for NestedLeaf<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:NestedLeaf)
-    let label = borrow::Cow::Borrowed(reader.read_str()?);
+    let label = borrow::Cow::Borrowed(reader.read_str().for_field("NestedLeaf", "label")?);
     // @@bebop_insertion_point(decode_end:NestedLeaf)
     result::Result::Ok(NestedLeaf { label })
   }
@@ -2613,19 +2777,23 @@ impl<'buf> bebop::BebopDecode<'buf> for DeepNestedCollections<'buf> {
       }
       match tag {
         1 => {
-          msg.nested = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              _r.read_array(|_r| {
-                _r.read_map(|_r| {
-                  result::Result::Ok((
-                    result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                    NestedLeaf::decode(_r)?,
-                  ))
-                })
-              })?,
-            ))
-          })?)
+          msg.nested = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  _r.read_array(|_r| {
+                    _r.read_map(|_r| {
+                      result::Result::Ok((
+                        result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                        NestedLeaf::decode(_r)?,
+                      ))
+                    })
+                  })?,
+                ))
+              })
+              .for_field("DeepNestedCollections", "nested")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -2702,7 +2870,8 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteMatrix<'buf> {
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:ByteMatrix)
     let rows = reader
-      .read_array(|_r| result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?)))?;
+      .read_array(|_r| result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?)))
+      .for_field("ByteMatrix", "rows")?;
     // @@bebop_insertion_point(decode_end:ByteMatrix)
     result::Result::Ok(ByteMatrix { rows })
   }
@@ -2772,12 +2941,14 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteTagMap<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:ByteTagMap)
-    let entries = reader.read_map(|_r| {
-      result::Result::Ok((
-        result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-        result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))?,
-      ))
-    })?;
+    let entries = reader
+      .read_map(|_r| {
+        result::Result::Ok((
+          result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+          result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))?,
+        ))
+      })
+      .for_field("ByteTagMap", "entries")?;
     // @@bebop_insertion_point(decode_end:ByteTagMap)
     result::Result::Ok(ByteTagMap { entries })
   }
@@ -2853,9 +3024,17 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteArrayMessage<'buf> {
         break;
       }
       match tag {
-        1 => msg.label = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        1 => {
+          msg.label = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("ByteArrayMessage", "label")?,
+          ))
+        }
         2 => {
-          msg.payload = option::Option::Some(bebop::BebopBytes::borrowed(reader.read_byte_slice()?))
+          msg.payload = option::Option::Some(bebop::BebopBytes::borrowed(
+            reader
+              .read_byte_slice()
+              .for_field("ByteArrayMessage", "payload")?,
+          ))
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -2962,17 +3141,25 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteCollectionMessage<'buf> {
       }
       match tag {
         1 => {
-          msg.matrix = option::Option::Some(reader.read_array(|_r| {
-            result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))
-          })?)
+          msg.matrix = option::Option::Some(
+            reader
+              .read_array(|_r| {
+                result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))
+              })
+              .for_field("ByteCollectionMessage", "matrix")?,
+          )
         }
         2 => {
-          msg.tagged = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))?,
-            ))
-          })?)
+          msg.tagged = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))?,
+                ))
+              })
+              .for_field("ByteCollectionMessage", "tagged")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -3060,8 +3247,8 @@ impl<'buf> bebop::BebopDecode<'buf> for UuidHolder<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:UuidHolder)
-    let id = reader.read_uuid()?;
-    let label = borrow::Cow::Borrowed(reader.read_str()?);
+    let id = reader.read_uuid().for_field("UuidHolder", "id")?;
+    let label = borrow::Cow::Borrowed(reader.read_str().for_field("UuidHolder", "label")?);
     // @@bebop_insertion_point(decode_end:UuidHolder)
     result::Result::Ok(UuidHolder { id, label })
   }

--- a/plugins/rust/integration-tests/src/test_types.rs
+++ b/plugins/rust/integration-tests/src/test_types.rs
@@ -17,17 +17,18 @@ extern crate bebop_runtime;
 extern crate core;
 use alloc::{borrow, boxed, string, vec};
 use bebop_runtime as bebop;
-use bebop_runtime::serde;
 use bebop_runtime::DecodeContext as _;
 use core::convert::Into as _;
 use core::iter::{IntoIterator as _, Iterator as _};
 use core::{convert, default, iter, mem, ops, option, result};
+use bebop_runtime::serde;
 
 // @@bebop_insertion_point(imports)
 
 /// Simple enum with uint8 base type.
 #[repr(u8)]
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Color {
   Unknown = 0,
   Red = 1,
@@ -43,18 +44,13 @@ impl convert::TryFrom<u8> for Color {
       1 => result::Result::Ok(Self::Red),
       2 => result::Result::Ok(Self::Green),
       3 => result::Result::Ok(Self::Blue),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "Color",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "Color", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<Color> for u8 {
-  fn from(value: Color) -> u8 {
-    value as u8
-  }
+  fn from(value: Color) -> u8 { value as u8 }
 }
 
 impl Color {
@@ -69,9 +65,7 @@ impl bebop::BebopEncode for Color {
     // @@bebop_insertion_point(encode_end:Color)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for Color {
@@ -84,7 +78,8 @@ impl<'buf> bebop::BebopDecode<'buf> for Color {
   }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Permissions(pub u8);
 
 #[allow(non_upper_case_globals)]
@@ -101,68 +96,24 @@ impl Permissions {
 impl bebop::BebopFlags for Permissions {
   type Bits = u8;
   const ALL_BITS: Self::Bits = 7;
-  fn bits(self) -> Self::Bits {
-    self.0
-  }
-  fn from_bits_retain(bits: Self::Bits) -> Self {
-    Self(bits)
-  }
+  fn bits(self) -> Self::Bits { self.0 }
+  fn from_bits_retain(bits: Self::Bits) -> Self { Self(bits) }
 }
 
-impl ops::BitOr for Permissions {
-  type Output = Self;
-  fn bitor(self, rhs: Self) -> Self {
-    Self(self.0 | rhs.0)
-  }
-}
-impl ops::BitOrAssign for Permissions {
-  fn bitor_assign(&mut self, rhs: Self) {
-    self.0 |= rhs.0;
-  }
-}
-impl ops::BitAnd for Permissions {
-  type Output = Self;
-  fn bitand(self, rhs: Self) -> Self {
-    Self(self.0 & rhs.0)
-  }
-}
-impl ops::BitAndAssign for Permissions {
-  fn bitand_assign(&mut self, rhs: Self) {
-    self.0 &= rhs.0;
-  }
-}
-impl ops::BitXor for Permissions {
-  type Output = Self;
-  fn bitxor(self, rhs: Self) -> Self {
-    Self(self.0 ^ rhs.0)
-  }
-}
-impl ops::BitXorAssign for Permissions {
-  fn bitxor_assign(&mut self, rhs: Self) {
-    self.0 ^= rhs.0;
-  }
-}
-impl ops::Not for Permissions {
-  type Output = Self;
-  fn not(self) -> Self {
-    Self(!self.0)
-  }
-}
-impl ops::Sub for Permissions {
-  type Output = Self;
-  fn sub(self, rhs: Self) -> Self {
-    Self(self.0 & !rhs.0)
-  }
-}
+impl ops::BitOr for Permissions { type Output = Self; fn bitor(self, rhs: Self) -> Self { Self(self.0 | rhs.0) } }
+impl ops::BitOrAssign for Permissions { fn bitor_assign(&mut self, rhs: Self) { self.0 |= rhs.0; } }
+impl ops::BitAnd for Permissions { type Output = Self; fn bitand(self, rhs: Self) -> Self { Self(self.0 & rhs.0) } }
+impl ops::BitAndAssign for Permissions { fn bitand_assign(&mut self, rhs: Self) { self.0 &= rhs.0; } }
+impl ops::BitXor for Permissions { type Output = Self; fn bitxor(self, rhs: Self) -> Self { Self(self.0 ^ rhs.0) } }
+impl ops::BitXorAssign for Permissions { fn bitxor_assign(&mut self, rhs: Self) { self.0 ^= rhs.0; } }
+impl ops::Not for Permissions { type Output = Self; fn not(self) -> Self { Self(!self.0) } }
+impl ops::Sub for Permissions { type Output = Self; fn sub(self, rhs: Self) -> Self { Self(self.0 & !rhs.0) } }
 
 impl<'buf> bebop::BebopDecode<'buf> for Permissions {
   #[inline(always)]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     let bits = reader.read_byte()?;
-    <Self as bebop::BebopFlags>::from_bits(bits).ok_or(bebop::DecodeError::InvalidFlags {
-      type_name: "Permissions",
-      bits: bits as u64,
-    })
+    <Self as bebop::BebopFlags>::from_bits(bits).ok_or(bebop::DecodeError::InvalidFlags { type_name: "Permissions", bits: bits as u64 })
   }
 }
 
@@ -191,9 +142,7 @@ pub const FEATURE_FLAG_ENABLED: bool = true;
 
 pub const EXAMPLE_CONST_STRING: &str = "hello \"world\"\nwith newlines";
 
-pub const EXAMPLE_CONST_GUID: bebop::Uuid = bebop::Uuid::from_bytes([
-  0xE2, 0x15, 0xA9, 0x46, 0xB2, 0x6F, 0x45, 0x67, 0xA2, 0x76, 0x13, 0x13, 0x6F, 0x0A, 0x17, 0x08,
-]);
+pub const EXAMPLE_CONST_GUID: bebop::Uuid = bebop::Uuid::from_bytes([0xE2, 0x15, 0xA9, 0x46, 0xB2, 0x6F, 0x45, 0x67, 0xA2, 0x76, 0x13, 0x13, 0x6F, 0x0A, 0x17, 0x08]);
 
 pub const EXAMPLE_CONST_F16: bebop::f16 = bebop::f16::from_f64_const(1.5f64);
 
@@ -212,7 +161,8 @@ pub const EXAMPLE_CONST_F16_FROM_INT: bebop::f16 = bebop::f16::from_f64_const(1f
 pub const EXAMPLE_CONST_BF16_FROM_INT: bebop::bf16 = bebop::bf16::from_f64_const(2f64);
 
 /// Fixed-size struct (all scalar fields).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Point {
   pub x: f32,
   pub y: f32,
@@ -221,7 +171,10 @@ pub struct Point {
 impl Point {
   pub const FIXED_ENCODED_SIZE: usize = mem::size_of::<f32>() + mem::size_of::<f32>();
 
-  pub fn new(x: f32, y: f32) -> Self {
+  pub fn new(
+    x: f32,
+    y: f32,
+  ) -> Self {
     Self { x, y }
   }
 }
@@ -255,7 +208,8 @@ impl Point {
 }
 
 /// Fixed-size struct referencing another struct and an enum.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Pixel {
   pub position: Point,
   pub color: Color,
@@ -264,14 +218,16 @@ pub struct Pixel {
 
 impl Pixel {
   pub const FIXED_ENCODED_SIZE: usize =
-    Point::FIXED_ENCODED_SIZE + Color::FIXED_ENCODED_SIZE + mem::size_of::<u8>();
+    Point::FIXED_ENCODED_SIZE
+    + Color::FIXED_ENCODED_SIZE
+    + mem::size_of::<u8>();
 
-  pub fn new(position: Point, color: Color, alpha: u8) -> Self {
-    Self {
-      position,
-      color,
-      alpha,
-    }
+  pub fn new(
+    position: Point,
+    color: Color,
+    alpha: u8,
+  ) -> Self {
+    Self { position, color, alpha }
   }
 }
 
@@ -297,11 +253,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Pixel {
     let color = Color::decode(reader).for_field("Pixel", "color")?;
     let alpha = reader.read_byte().for_field("Pixel", "alpha")?;
     // @@bebop_insertion_point(decode_end:Pixel)
-    result::Result::Ok(Pixel {
-      position,
-      color,
-      alpha,
-    })
+    result::Result::Ok(Pixel { position, color, alpha })
   }
 }
 
@@ -310,7 +262,8 @@ impl Pixel {
 }
 
 /// Variable-size struct with a string field (needs lifetime / Cow).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Person<'buf> {
   pub name: borrow::Cow<'buf, str>,
   pub age: u32,
@@ -319,7 +272,10 @@ pub struct Person<'buf> {
 pub type PersonOwned = Person<'static>;
 
 impl<'buf> Person<'buf> {
-  pub fn new(name: impl convert::Into<borrow::Cow<'buf, str>>, age: u32) -> Self {
+  pub fn new(
+    name: impl convert::Into<borrow::Cow<'buf, str>>,
+    age: u32,
+  ) -> Self {
     let name = name.into();
     Self { name, age }
   }
@@ -366,7 +322,8 @@ impl<'buf> Person<'buf> {
 }
 
 /// Variable-size struct with a byte array field (needs lifetime / Cow).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BinaryPayload<'buf> {
   pub tag: u32,
   pub data: bebop::BebopBytes<'buf>,
@@ -375,7 +332,10 @@ pub struct BinaryPayload<'buf> {
 pub type BinaryPayloadOwned = BinaryPayload<'static>;
 
 impl<'buf> BinaryPayload<'buf> {
-  pub fn new(tag: u32, data: impl convert::Into<bebop::BebopBytes<'buf>>) -> Self {
+  pub fn new(
+    tag: u32,
+    data: impl convert::Into<bebop::BebopBytes<'buf>>,
+  ) -> Self {
     let data = data.into();
     Self { tag, data }
   }
@@ -411,11 +371,7 @@ impl<'buf> bebop::BebopDecode<'buf> for BinaryPayload<'buf> {
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:BinaryPayload)
     let tag = reader.read_u32().for_field("BinaryPayload", "tag")?;
-    let data = bebop::BebopBytes::borrowed(
-      reader
-        .read_byte_slice()
-        .for_field("BinaryPayload", "data")?,
-    );
+    let data = bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field("BinaryPayload", "data")?);
     // @@bebop_insertion_point(decode_end:BinaryPayload)
     result::Result::Ok(BinaryPayload { tag, data })
   }
@@ -426,7 +382,8 @@ impl<'buf> BinaryPayload<'buf> {
 }
 
 /// Message with various field types: scalars, strings, arrays, maps.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct UserProfile<'buf> {
   pub display_name: option::Option<borrow::Cow<'buf, str>>,
   pub email: option::Option<borrow::Cow<'buf, str>>,
@@ -442,27 +399,12 @@ pub type UserProfileOwned = UserProfile<'static>;
 impl<'buf> UserProfile<'buf> {
   pub fn into_owned(self) -> UserProfileOwned {
     UserProfile {
-      display_name: self
-        .display_name
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      display_name: self.display_name.map(|v| borrow::Cow::Owned(v.into_owned())),
       email: self.email.map(|v| borrow::Cow::Owned(v.into_owned())),
       age: self.age,
       active: self.active,
-      tags: self.tags.map(|v| {
-        v.into_iter()
-          .map(|_e| borrow::Cow::Owned(_e.into_owned()))
-          .collect()
-      }),
-      metadata: self.metadata.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| {
-            (
-              borrow::Cow::Owned(_k.into_owned()),
-              borrow::Cow::Owned(_v.into_owned()),
-            )
-          })
-          .collect()
-      }),
+      tags: self.tags.map(|v| v.into_iter().map(|_e| borrow::Cow::Owned(_e.into_owned())).collect()),
+      metadata: self.metadata.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), borrow::Cow::Owned(_v.into_owned()))).collect()),
       permissions: self.permissions,
     }
   }
@@ -499,10 +441,7 @@ impl<'buf> bebop::BebopEncode for UserProfile<'buf> {
     }
     if let option::Option::Some(ref v) = self.metadata {
       writer.write_tag(6);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _w.write_string(&_v);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _w.write_string(&_v); });
     }
     if let option::Option::Some(ref v) = self.permissions {
       writer.write_tag(7);
@@ -528,14 +467,10 @@ impl<'buf> bebop::BebopEncode for UserProfile<'buf> {
       size += bebop::wire_size::tagged_size(mem::size_of::<bool>());
     }
     if let option::Option::Some(ref v) = self.tags {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| {
-        bebop::wire_size::string_size(_el.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| bebop::wire_size::string_size(_el.len())));
     }
     if let option::Option::Some(ref v) = self.metadata {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len()) + bebop::wire_size::string_size(_v.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + bebop::wire_size::string_size(_v.len())));
     }
     if let option::Option::Some(ref v) = self.permissions {
       size += bebop::wire_size::tagged_size(v.encoded_size());
@@ -554,54 +489,16 @@ impl<'buf> bebop::BebopDecode<'buf> for UserProfile<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.display_name = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("UserProfile", "display_name")?,
-          ))
-        }
-        2 => {
-          msg.email = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("UserProfile", "email")?,
-          ))
-        }
+        1 => msg.display_name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("UserProfile", "display_name")?)),
+        2 => msg.email = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("UserProfile", "email")?)),
         3 => msg.age = option::Option::Some(reader.read_u32().for_field("UserProfile", "age")?),
-        4 => {
-          msg.active = option::Option::Some(reader.read_bool().for_field("UserProfile", "active")?)
-        }
-        5 => {
-          msg.tags = option::Option::Some(
-            reader
-              .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
-              .for_field("UserProfile", "tags")?,
-          )
-        }
-        6 => {
-          msg.metadata = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                ))
-              })
-              .for_field("UserProfile", "metadata")?,
-          )
-        }
-        7 => {
-          msg.permissions = option::Option::Some(
-            Permissions::decode(reader).for_field("UserProfile", "permissions")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "UserProfile",
-            tag,
-          });
-        }
+        4 => msg.active = option::Option::Some(reader.read_bool().for_field("UserProfile", "active")?),
+        5 => msg.tags = option::Option::Some(reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))).for_field("UserProfile", "tags")?),
+        6 => msg.metadata = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?))).for_field("UserProfile", "metadata")?),
+        7 => msg.permissions = option::Option::Some(Permissions::decode(reader).for_field("UserProfile", "permissions")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "UserProfile", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:UserProfile)
@@ -626,28 +523,12 @@ impl<'buf> UserProfile<'buf> {
     self.active = option::Option::Some(value);
     self
   }
-  pub fn with_tags(
-    mut self,
-    value: impl iter::IntoIterator<Item = impl convert::Into<borrow::Cow<'buf, str>>>,
-  ) -> Self {
+  pub fn with_tags(mut self, value: impl iter::IntoIterator<Item = impl convert::Into<borrow::Cow<'buf, str>>>) -> Self {
     self.tags = option::Option::Some(value.into_iter().map(|_e| _e.into()).collect());
     self
   }
-  pub fn with_metadata(
-    mut self,
-    value: impl iter::IntoIterator<
-      Item = (
-        impl convert::Into<borrow::Cow<'buf, str>>,
-        impl convert::Into<borrow::Cow<'buf, str>>,
-      ),
-    >,
-  ) -> Self {
-    self.metadata = option::Option::Some(
-      value
-        .into_iter()
-        .map(|(_k, _v)| (_k.into(), _v.into()))
-        .collect(),
-    );
+  pub fn with_metadata(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, impl convert::Into<borrow::Cow<'buf, str>>)>) -> Self {
+    self.metadata = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v.into())).collect());
     self
   }
   pub fn with_permissions(mut self, value: Permissions) -> Self {
@@ -658,7 +539,8 @@ impl<'buf> UserProfile<'buf> {
 }
 
 /// Message referencing fixed-size and enum defined types.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct DrawCommand<'buf> {
   pub target: option::Option<Point>,
   pub color: option::Option<Color>,
@@ -737,32 +619,13 @@ impl<'buf> bebop::BebopDecode<'buf> for DrawCommand<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.target =
-            option::Option::Some(Point::decode(reader).for_field("DrawCommand", "target")?)
-        }
-        2 => {
-          msg.color = option::Option::Some(Color::decode(reader).for_field("DrawCommand", "color")?)
-        }
-        3 => {
-          msg.label = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("DrawCommand", "label")?,
-          ))
-        }
-        4 => {
-          msg.thickness =
-            option::Option::Some(reader.read_f32().for_field("DrawCommand", "thickness")?)
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "DrawCommand",
-            tag,
-          });
-        }
+        1 => msg.target = option::Option::Some(Point::decode(reader).for_field("DrawCommand", "target")?),
+        2 => msg.color = option::Option::Some(Color::decode(reader).for_field("DrawCommand", "color")?),
+        3 => msg.label = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DrawCommand", "label")?)),
+        4 => msg.thickness = option::Option::Some(reader.read_f32().for_field("DrawCommand", "thickness")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "DrawCommand", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:DrawCommand)
@@ -791,7 +654,8 @@ impl<'buf> DrawCommand<'buf> {
 }
 
 /// Struct used as a union branch (variable-size due to string field).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TextLabel<'buf> {
   pub position: Point,
   pub text: borrow::Cow<'buf, str>,
@@ -800,7 +664,10 @@ pub struct TextLabel<'buf> {
 pub type TextLabelOwned = TextLabel<'static>;
 
 impl<'buf> TextLabel<'buf> {
-  pub fn new(position: Point, text: impl convert::Into<borrow::Cow<'buf, str>>) -> Self {
+  pub fn new(
+    position: Point,
+    text: impl convert::Into<borrow::Cow<'buf, str>>,
+  ) -> Self {
     let text = text.into();
     Self { position, text }
   }
@@ -875,36 +742,23 @@ impl<'buf> bebop::BebopEncode for Shape<'buf> {
     // @@bebop_insertion_point(encode_start:Shape)
     let pos = writer.reserve_message_length();
     match self {
-      Self::Point(inner) => {
-        writer.write_byte(1);
-        inner.encode(writer);
-      }
-      Self::Pixel(inner) => {
-        writer.write_byte(2);
-        inner.encode(writer);
-      }
-      Self::Label(inner) => {
-        writer.write_byte(3);
-        inner.encode(writer);
-      }
+      Self::Point(inner) => { writer.write_byte(1); inner.encode(writer); }
+      Self::Pixel(inner) => { writer.write_byte(2); inner.encode(writer); }
+      Self::Label(inner) => { writer.write_byte(3); inner.encode(writer); }
       // @@bebop_insertion_point(encode_switch:Shape)
-      Self::Unknown(disc, data) => {
-        writer.write_byte(*disc);
-        writer.write_raw(data);
-      }
+      Self::Unknown(disc, data) => { writer.write_byte(*disc); writer.write_raw(data); }
     }
     writer.fill_message_length(pos);
     // @@bebop_insertion_point(encode_end:Shape)
   }
 
   fn encoded_size(&self) -> usize {
-    bebop::wire_size::WIRE_LEN_PREFIX_SIZE
-      + match self {
-        Self::Point(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::Pixel(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::Label(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::Unknown(_, data) => bebop::wire_size::tagged_size(data.len()),
-      }
+    bebop::wire_size::WIRE_LEN_PREFIX_SIZE + match self {
+      Self::Point(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::Pixel(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::Label(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::Unknown(_, data) => bebop::wire_size::tagged_size(data.len()),
+    }
   }
 }
 
@@ -916,15 +770,9 @@ impl<'buf> bebop::BebopDecode<'buf> for Shape<'buf> {
     let start = reader.position();
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
-      1 => result::Result::Ok(Self::Point(
-        Point::decode(reader).for_field("Shape", "point")?,
-      )),
-      2 => result::Result::Ok(Self::Pixel(
-        Pixel::decode(reader).for_field("Shape", "pixel")?,
-      )),
-      3 => result::Result::Ok(Self::Label(
-        TextLabel::decode(reader).for_field("Shape", "label")?,
-      )),
+      1 => result::Result::Ok(Self::Point(Point::decode(reader).for_field("Shape", "point")?)),
+      2 => result::Result::Ok(Self::Pixel(Pixel::decode(reader).for_field("Shape", "pixel")?)),
+      3 => result::Result::Ok(Self::Label(TextLabel::decode(reader).for_field("Shape", "label")?)),
       // @@bebop_insertion_point(decode_switch:Shape)
       _ => {
         let remaining = length - (reader.position() - start);
@@ -955,25 +803,18 @@ impl bebop::BebopEncode for StrictShape {
     // @@bebop_insertion_point(encode_start:StrictShape)
     let pos = writer.reserve_message_length();
     match self {
-      Self::Point(inner) => {
-        writer.write_byte(1);
-        inner.encode(writer);
-      }
-      Self::Pixel(inner) => {
-        writer.write_byte(2);
-        inner.encode(writer);
-      }
+      Self::Point(inner) => { writer.write_byte(1); inner.encode(writer); }
+      Self::Pixel(inner) => { writer.write_byte(2); inner.encode(writer); }
     }
     writer.fill_message_length(pos);
     // @@bebop_insertion_point(encode_end:StrictShape)
   }
 
   fn encoded_size(&self) -> usize {
-    bebop::wire_size::WIRE_LEN_PREFIX_SIZE
-      + match self {
-        Self::Point(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-        Self::Pixel(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
-      }
+    bebop::wire_size::WIRE_LEN_PREFIX_SIZE + match self {
+      Self::Point(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+      Self::Pixel(inner) => bebop::wire_size::tagged_size(inner.encoded_size()),
+    }
   }
 }
 
@@ -985,16 +826,9 @@ impl<'buf> bebop::BebopDecode<'buf> for StrictShape {
     let start = reader.position();
     let discriminator = reader.read_byte()?;
     let value = match discriminator {
-      1 => result::Result::Ok(Self::Point(
-        Point::decode(reader).for_field("StrictShape", "point")?,
-      )),
-      2 => result::Result::Ok(Self::Pixel(
-        Pixel::decode(reader).for_field("StrictShape", "pixel")?,
-      )),
-      _ => result::Result::Err(bebop::DecodeError::InvalidUnion {
-        type_name: "StrictShape",
-        discriminator,
-      }),
+      1 => result::Result::Ok(Self::Point(Point::decode(reader).for_field("StrictShape", "point")?)),
+      2 => result::Result::Ok(Self::Pixel(Pixel::decode(reader).for_field("StrictShape", "pixel")?)),
+      _ => result::Result::Err(bebop::DecodeError::InvalidUnion { type_name: "StrictShape", discriminator }),
     };
     // @@bebop_insertion_point(decode_end:StrictShape)
     value
@@ -1005,7 +839,8 @@ impl StrictShape {
   // @@bebop_insertion_point(union_scope:StrictShape)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Priority {
   Unspecified,
   Low,
@@ -1049,9 +884,7 @@ impl convert::From<u8> for Priority {
 }
 
 impl convert::From<Priority> for u8 {
-  fn from(value: Priority) -> u8 {
-    value.discriminator()
-  }
+  fn from(value: Priority) -> u8 { value.discriminator() }
 }
 
 impl bebop::BebopEncode for Priority {
@@ -1061,9 +894,7 @@ impl bebop::BebopEncode for Priority {
     // @@bebop_insertion_point(encode_end:Priority)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for Priority {
@@ -1077,7 +908,8 @@ impl<'buf> bebop::BebopDecode<'buf> for Priority {
 }
 
 /// Strict message: unknown field tags are rejected with DecodeError.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct StrictConfig<'buf> {
   pub name: option::Option<borrow::Cow<'buf, str>>,
   pub value: option::Option<u32>,
@@ -1138,24 +970,11 @@ impl<'buf> bebop::BebopDecode<'buf> for StrictConfig<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("StrictConfig", "name")?,
-          ))
-        }
-        2 => {
-          msg.value = option::Option::Some(reader.read_u32().for_field("StrictConfig", "value")?)
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "StrictConfig",
-            tag,
-          });
-        }
+        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("StrictConfig", "name")?)),
+        2 => msg.value = option::Option::Some(reader.read_u32().for_field("StrictConfig", "value")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "StrictConfig", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:StrictConfig)
@@ -1175,7 +994,8 @@ impl<'buf> StrictConfig<'buf> {
   // @@bebop_insertion_point(message_scope:StrictConfig)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct FlexConfig<'buf> {
   pub name: option::Option<borrow::Cow<'buf, str>>,
   pub value: option::Option<u32>,
@@ -1236,19 +1056,11 @@ impl<'buf> bebop::BebopDecode<'buf> for FlexConfig<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("FlexConfig", "name")?,
-          ))
-        }
+        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("FlexConfig", "name")?)),
         2 => msg.value = option::Option::Some(reader.read_u32().for_field("FlexConfig", "value")?),
-        _ => {
-          reader.skip(end - reader.position())?;
-        }
+        _ => { reader.skip(end - reader.position())?; }
       }
     }
     // @@bebop_insertion_point(decode_end:FlexConfig)
@@ -1268,7 +1080,8 @@ impl<'buf> FlexConfig<'buf> {
   // @@bebop_insertion_point(message_scope:FlexConfig)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FlexPermissions(pub u8);
 
 #[allow(non_upper_case_globals)]
@@ -1283,59 +1096,18 @@ impl FlexPermissions {
 impl bebop::BebopFlags for FlexPermissions {
   type Bits = u8;
   const ALL_BITS: Self::Bits = 3;
-  fn bits(self) -> Self::Bits {
-    self.0
-  }
-  fn from_bits_retain(bits: Self::Bits) -> Self {
-    Self(bits)
-  }
+  fn bits(self) -> Self::Bits { self.0 }
+  fn from_bits_retain(bits: Self::Bits) -> Self { Self(bits) }
 }
 
-impl ops::BitOr for FlexPermissions {
-  type Output = Self;
-  fn bitor(self, rhs: Self) -> Self {
-    Self(self.0 | rhs.0)
-  }
-}
-impl ops::BitOrAssign for FlexPermissions {
-  fn bitor_assign(&mut self, rhs: Self) {
-    self.0 |= rhs.0;
-  }
-}
-impl ops::BitAnd for FlexPermissions {
-  type Output = Self;
-  fn bitand(self, rhs: Self) -> Self {
-    Self(self.0 & rhs.0)
-  }
-}
-impl ops::BitAndAssign for FlexPermissions {
-  fn bitand_assign(&mut self, rhs: Self) {
-    self.0 &= rhs.0;
-  }
-}
-impl ops::BitXor for FlexPermissions {
-  type Output = Self;
-  fn bitxor(self, rhs: Self) -> Self {
-    Self(self.0 ^ rhs.0)
-  }
-}
-impl ops::BitXorAssign for FlexPermissions {
-  fn bitxor_assign(&mut self, rhs: Self) {
-    self.0 ^= rhs.0;
-  }
-}
-impl ops::Not for FlexPermissions {
-  type Output = Self;
-  fn not(self) -> Self {
-    Self(!self.0)
-  }
-}
-impl ops::Sub for FlexPermissions {
-  type Output = Self;
-  fn sub(self, rhs: Self) -> Self {
-    Self(self.0 & !rhs.0)
-  }
-}
+impl ops::BitOr for FlexPermissions { type Output = Self; fn bitor(self, rhs: Self) -> Self { Self(self.0 | rhs.0) } }
+impl ops::BitOrAssign for FlexPermissions { fn bitor_assign(&mut self, rhs: Self) { self.0 |= rhs.0; } }
+impl ops::BitAnd for FlexPermissions { type Output = Self; fn bitand(self, rhs: Self) -> Self { Self(self.0 & rhs.0) } }
+impl ops::BitAndAssign for FlexPermissions { fn bitand_assign(&mut self, rhs: Self) { self.0 &= rhs.0; } }
+impl ops::BitXor for FlexPermissions { type Output = Self; fn bitxor(self, rhs: Self) -> Self { Self(self.0 ^ rhs.0) } }
+impl ops::BitXorAssign for FlexPermissions { fn bitxor_assign(&mut self, rhs: Self) { self.0 ^= rhs.0; } }
+impl ops::Not for FlexPermissions { type Output = Self; fn not(self) -> Self { Self(!self.0) } }
+impl ops::Sub for FlexPermissions { type Output = Self; fn sub(self, rhs: Self) -> Self { Self(self.0 & !rhs.0) } }
 
 impl<'buf> bebop::BebopDecode<'buf> for FlexPermissions {
   #[inline(always)]
@@ -1346,7 +1118,8 @@ impl<'buf> bebop::BebopDecode<'buf> for FlexPermissions {
 }
 
 /// Fixed-array struct (compile-time known element count).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Matrix2x2 {
   pub values: [f32; 4],
 }
@@ -1375,9 +1148,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Matrix2x2 {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Matrix2x2)
-    let values = reader
-      .read_fixed_array::<f32, 4>()
-      .for_field("Matrix2x2", "values")?;
+    let values = reader.read_fixed_array::<f32, 4>().for_field("Matrix2x2", "values")?;
     // @@bebop_insertion_point(decode_end:Matrix2x2)
     result::Result::Ok(Matrix2x2 { values })
   }
@@ -1388,17 +1159,20 @@ impl Matrix2x2 {
 }
 
 /// Fixed-size and variable-size half-precision scalar coverage.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HalfPrecisionScalars {
   pub f16_val: bebop::f16,
   pub bf16_val: bebop::bf16,
 }
 
 impl HalfPrecisionScalars {
-  pub const FIXED_ENCODED_SIZE: usize =
-    mem::size_of::<bebop::f16>() + mem::size_of::<bebop::bf16>();
+  pub const FIXED_ENCODED_SIZE: usize = mem::size_of::<bebop::f16>() + mem::size_of::<bebop::bf16>();
 
-  pub fn new(f16_val: bebop::f16, bf16_val: bebop::bf16) -> Self {
+  pub fn new(
+    f16_val: bebop::f16,
+    bf16_val: bebop::bf16,
+  ) -> Self {
     Self { f16_val, bf16_val }
   }
 }
@@ -1420,12 +1194,8 @@ impl<'buf> bebop::BebopDecode<'buf> for HalfPrecisionScalars {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:HalfPrecisionScalars)
-    let f16_val = reader
-      .read_f16()
-      .for_field("HalfPrecisionScalars", "f16_val")?;
-    let bf16_val = reader
-      .read_bf16()
-      .for_field("HalfPrecisionScalars", "bf16_val")?;
+    let f16_val = reader.read_f16().for_field("HalfPrecisionScalars", "f16_val")?;
+    let bf16_val = reader.read_bf16().for_field("HalfPrecisionScalars", "bf16_val")?;
     // @@bebop_insertion_point(decode_end:HalfPrecisionScalars)
     result::Result::Ok(HalfPrecisionScalars { f16_val, bf16_val })
   }
@@ -1435,7 +1205,8 @@ impl HalfPrecisionScalars {
   // @@bebop_insertion_point(struct_scope:HalfPrecisionScalars)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct HalfPrecisionArrays<'buf> {
   pub f16_dynamic: borrow::Cow<'buf, [bebop::f16]>,
   pub bf16_dynamic: borrow::Cow<'buf, [bebop::bf16]>,
@@ -1454,12 +1225,7 @@ impl<'buf> HalfPrecisionArrays<'buf> {
   ) -> Self {
     let f16_dynamic = f16_dynamic.into();
     let bf16_dynamic = bf16_dynamic.into();
-    Self {
-      f16_dynamic,
-      bf16_dynamic,
-      f16_fixed,
-      bf16_fixed,
-    }
+    Self { f16_dynamic, bf16_dynamic, f16_fixed, bf16_fixed }
   }
 }
 
@@ -1498,25 +1264,12 @@ impl<'buf> bebop::BebopDecode<'buf> for HalfPrecisionArrays<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:HalfPrecisionArrays)
-    let f16_dynamic = reader
-      .read_scalar_array::<bebop::f16>()
-      .for_field("HalfPrecisionArrays", "f16_dynamic")?;
-    let bf16_dynamic = reader
-      .read_scalar_array::<bebop::bf16>()
-      .for_field("HalfPrecisionArrays", "bf16_dynamic")?;
-    let f16_fixed = reader
-      .read_fixed_array::<bebop::f16, 4>()
-      .for_field("HalfPrecisionArrays", "f16_fixed")?;
-    let bf16_fixed = reader
-      .read_fixed_array::<bebop::bf16, 4>()
-      .for_field("HalfPrecisionArrays", "bf16_fixed")?;
+    let f16_dynamic = reader.read_scalar_array::<bebop::f16>().for_field("HalfPrecisionArrays", "f16_dynamic")?;
+    let bf16_dynamic = reader.read_scalar_array::<bebop::bf16>().for_field("HalfPrecisionArrays", "bf16_dynamic")?;
+    let f16_fixed = reader.read_fixed_array::<bebop::f16, 4>().for_field("HalfPrecisionArrays", "f16_fixed")?;
+    let bf16_fixed = reader.read_fixed_array::<bebop::bf16, 4>().for_field("HalfPrecisionArrays", "bf16_fixed")?;
     // @@bebop_insertion_point(decode_end:HalfPrecisionArrays)
-    result::Result::Ok(HalfPrecisionArrays {
-      f16_dynamic,
-      bf16_dynamic,
-      f16_fixed,
-      bf16_fixed,
-    })
+    result::Result::Ok(HalfPrecisionArrays { f16_dynamic, bf16_dynamic, f16_fixed, bf16_fixed })
   }
 }
 
@@ -1524,7 +1277,8 @@ impl<'buf> HalfPrecisionArrays<'buf> {
   // @@bebop_insertion_point(struct_scope:HalfPrecisionArrays)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct HalfPrecisionMessage<'buf> {
   pub f16_val: option::Option<bebop::f16>,
   pub bf16_val: option::Option<bebop::bf16>,
@@ -1584,14 +1338,10 @@ impl<'buf> bebop::BebopEncode for HalfPrecisionMessage<'buf> {
       size += bebop::wire_size::tagged_size(mem::size_of::<bebop::bf16>());
     }
     if let option::Option::Some(ref v) = self.f16_arr {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| {
-        (mem::size_of::<bebop::f16>())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| (mem::size_of::<bebop::f16>())));
     }
     if let option::Option::Some(ref v) = self.bf16_arr {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| {
-        (mem::size_of::<bebop::bf16>())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| (mem::size_of::<bebop::bf16>())));
     }
     size
   }
@@ -1607,44 +1357,13 @@ impl<'buf> bebop::BebopDecode<'buf> for HalfPrecisionMessage<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.f16_val = option::Option::Some(
-            reader
-              .read_f16()
-              .for_field("HalfPrecisionMessage", "f16_val")?,
-          )
-        }
-        2 => {
-          msg.bf16_val = option::Option::Some(
-            reader
-              .read_bf16()
-              .for_field("HalfPrecisionMessage", "bf16_val")?,
-          )
-        }
-        3 => {
-          msg.f16_arr = option::Option::Some(
-            reader
-              .read_scalar_array::<bebop::f16>()
-              .for_field("HalfPrecisionMessage", "f16_arr")?,
-          )
-        }
-        4 => {
-          msg.bf16_arr = option::Option::Some(
-            reader
-              .read_scalar_array::<bebop::bf16>()
-              .for_field("HalfPrecisionMessage", "bf16_arr")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "HalfPrecisionMessage",
-            tag,
-          });
-        }
+        1 => msg.f16_val = option::Option::Some(reader.read_f16().for_field("HalfPrecisionMessage", "f16_val")?),
+        2 => msg.bf16_val = option::Option::Some(reader.read_bf16().for_field("HalfPrecisionMessage", "bf16_val")?),
+        3 => msg.f16_arr = option::Option::Some(reader.read_scalar_array::<bebop::f16>().for_field("HalfPrecisionMessage", "f16_arr")?),
+        4 => msg.bf16_arr = option::Option::Some(reader.read_scalar_array::<bebop::bf16>().for_field("HalfPrecisionMessage", "bf16_arr")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "HalfPrecisionMessage", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:HalfPrecisionMessage)
@@ -1661,17 +1380,11 @@ impl<'buf> HalfPrecisionMessage<'buf> {
     self.bf16_val = option::Option::Some(value);
     self
   }
-  pub fn with_f16_arr(
-    mut self,
-    value: impl convert::Into<borrow::Cow<'buf, [bebop::f16]>>,
-  ) -> Self {
+  pub fn with_f16_arr(mut self, value: impl convert::Into<borrow::Cow<'buf, [bebop::f16]>>) -> Self {
     self.f16_arr = option::Option::Some(value.into());
     self
   }
-  pub fn with_bf16_arr(
-    mut self,
-    value: impl convert::Into<borrow::Cow<'buf, [bebop::bf16]>>,
-  ) -> Self {
+  pub fn with_bf16_arr(mut self, value: impl convert::Into<borrow::Cow<'buf, [bebop::bf16]>>) -> Self {
     self.bf16_arr = option::Option::Some(value.into());
     self
   }
@@ -1679,7 +1392,8 @@ impl<'buf> HalfPrecisionMessage<'buf> {
 }
 
 /// Struct with multiple string fields (all need Cow).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Address<'buf> {
   pub street: borrow::Cow<'buf, str>,
   pub city: borrow::Cow<'buf, str>,
@@ -1700,12 +1414,7 @@ impl<'buf> Address<'buf> {
     let city = city.into();
     let country = country.into();
     let zip_code = zip_code.into();
-    Self {
-      street,
-      city,
-      country,
-      zip_code,
-    }
+    Self { street, city, country, zip_code }
   }
 }
 
@@ -1749,12 +1458,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Address<'buf> {
     let country = borrow::Cow::Borrowed(reader.read_str().for_field("Address", "country")?);
     let zip_code = borrow::Cow::Borrowed(reader.read_str().for_field("Address", "zip_code")?);
     // @@bebop_insertion_point(decode_end:Address)
-    result::Result::Ok(Address {
-      street,
-      city,
-      country,
-      zip_code,
-    })
+    result::Result::Ok(Address { street, city, country, zip_code })
   }
 }
 
@@ -1763,7 +1467,8 @@ impl<'buf> Address<'buf> {
 }
 
 /// Message with array-of-defined-type and nested references.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct Scene<'buf> {
   pub shapes: option::Option<vec::Vec<Shape<'buf>>>,
   pub background: option::Option<Color>,
@@ -1775,9 +1480,7 @@ pub type SceneOwned = Scene<'static>;
 impl<'buf> Scene<'buf> {
   pub fn into_owned(self) -> SceneOwned {
     Scene {
-      shapes: self
-        .shapes
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      shapes: self.shapes.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
       background: self.background,
       title: self.title.map(|v| borrow::Cow::Owned(v.into_owned())),
     }
@@ -1813,8 +1516,7 @@ impl<'buf> bebop::BebopEncode for Scene<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.shapes {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.background {
       size += bebop::wire_size::tagged_size(v.encoded_size());
@@ -1836,32 +1538,12 @@ impl<'buf> bebop::BebopDecode<'buf> for Scene<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.shapes = option::Option::Some(
-            reader
-              .read_array(|_r| Shape::decode(_r))
-              .for_field("Scene", "shapes")?,
-          )
-        }
-        2 => {
-          msg.background =
-            option::Option::Some(Color::decode(reader).for_field("Scene", "background")?)
-        }
-        3 => {
-          msg.title = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("Scene", "title")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "Scene",
-            tag,
-          });
-        }
+        1 => msg.shapes = option::Option::Some(reader.read_array(|_r| Shape::decode(_r)).for_field("Scene", "shapes")?),
+        2 => msg.background = option::Option::Some(Color::decode(reader).for_field("Scene", "background")?),
+        3 => msg.title = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Scene", "title")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "Scene", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:Scene)
@@ -1886,7 +1568,8 @@ impl<'buf> Scene<'buf> {
 }
 
 /// Message with map[string, defined-type] value.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Inventory<'buf> {
   pub items: option::Option<bebop::HashMap<borrow::Cow<'buf, str>, u32>>,
   pub label: option::Option<borrow::Cow<'buf, str>>,
@@ -1897,11 +1580,7 @@ pub type InventoryOwned = Inventory<'static>;
 impl<'buf> Inventory<'buf> {
   pub fn into_owned(self) -> InventoryOwned {
     Inventory {
-      items: self.items.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v))
-          .collect()
-      }),
+      items: self.items.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v)).collect()),
       label: self.label.map(|v| borrow::Cow::Owned(v.into_owned())),
     }
   }
@@ -1918,10 +1597,7 @@ impl<'buf> bebop::BebopEncode for Inventory<'buf> {
     // normally. This behavior should be revisited once the spec intent is clarified.
     if let option::Option::Some(ref v) = self.items {
       writer.write_tag(1);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _w.write_u32(*_v);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _w.write_u32(*_v); });
     }
     if let option::Option::Some(ref v) = self.label {
       writer.write_tag(2);
@@ -1935,9 +1611,7 @@ impl<'buf> bebop::BebopEncode for Inventory<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.items {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len()) + mem::size_of::<u32>()
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + mem::size_of::<u32>()));
     }
     if let option::Option::Some(ref v) = self.label {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
@@ -1956,33 +1630,11 @@ impl<'buf> bebop::BebopDecode<'buf> for Inventory<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.items = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  _r.read_u32()?,
-                ))
-              })
-              .for_field("Inventory", "items")?,
-          )
-        }
-        2 => {
-          msg.label = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("Inventory", "label")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "Inventory",
-            tag,
-          });
-        }
+        1 => msg.items = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, _r.read_u32()?))).for_field("Inventory", "items")?),
+        2 => msg.label = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Inventory", "label")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "Inventory", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:Inventory)
@@ -1991,10 +1643,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Inventory<'buf> {
 }
 
 impl<'buf> Inventory<'buf> {
-  pub fn with_items(
-    mut self,
-    value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, u32)>,
-  ) -> Self {
+  pub fn with_items(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, u32)>) -> Self {
     self.items = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v)).collect());
     self
   }
@@ -2006,7 +1655,8 @@ impl<'buf> Inventory<'buf> {
 }
 
 /// Empty message (all fields optional, none set).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct EmptyMessage<'buf> {
   pub unused_field: option::Option<borrow::Cow<'buf, str>>,
 }
@@ -2016,9 +1666,7 @@ pub type EmptyMessageOwned = EmptyMessage<'static>;
 impl<'buf> EmptyMessage<'buf> {
   pub fn into_owned(self) -> EmptyMessageOwned {
     EmptyMessage {
-      unused_field: self
-        .unused_field
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      unused_field: self.unused_field.map(|v| borrow::Cow::Owned(v.into_owned())),
     }
   }
 }
@@ -2060,23 +1708,10 @@ impl<'buf> bebop::BebopDecode<'buf> for EmptyMessage<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.unused_field = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("EmptyMessage", "unused_field")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "EmptyMessage",
-            tag,
-          });
-        }
+        1 => msg.unused_field = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("EmptyMessage", "unused_field")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "EmptyMessage", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:EmptyMessage)
@@ -2093,7 +1728,8 @@ impl<'buf> EmptyMessage<'buf> {
 }
 
 /// Struct with a timestamp field.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TimestampedEvent<'buf> {
   pub when: bebop::BebopTimestamp,
   pub what: borrow::Cow<'buf, str>,
@@ -2140,9 +1776,7 @@ impl<'buf> bebop::BebopDecode<'buf> for TimestampedEvent<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:TimestampedEvent)
-    let when = reader
-      .read_timestamp()
-      .for_field("TimestampedEvent", "when")?;
+    let when = reader.read_timestamp().for_field("TimestampedEvent", "when")?;
     let what = borrow::Cow::Borrowed(reader.read_str().for_field("TimestampedEvent", "what")?);
     // @@bebop_insertion_point(decode_end:TimestampedEvent)
     result::Result::Ok(TimestampedEvent { when, what })
@@ -2154,7 +1788,8 @@ impl<'buf> TimestampedEvent<'buf> {
 }
 
 /// Message with temporal fields.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct ScheduleEntry<'buf> {
   pub start: option::Option<bebop::BebopTimestamp>,
   pub duration: option::Option<bebop::BebopDuration>,
@@ -2224,35 +1859,12 @@ impl<'buf> bebop::BebopDecode<'buf> for ScheduleEntry<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.start = option::Option::Some(
-            reader
-              .read_timestamp()
-              .for_field("ScheduleEntry", "start")?,
-          )
-        }
-        2 => {
-          msg.duration = option::Option::Some(
-            reader
-              .read_duration()
-              .for_field("ScheduleEntry", "duration")?,
-          )
-        }
-        3 => {
-          msg.label = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("ScheduleEntry", "label")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "ScheduleEntry",
-            tag,
-          });
-        }
+        1 => msg.start = option::Option::Some(reader.read_timestamp().for_field("ScheduleEntry", "start")?),
+        2 => msg.duration = option::Option::Some(reader.read_duration().for_field("ScheduleEntry", "duration")?),
+        3 => msg.label = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("ScheduleEntry", "label")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "ScheduleEntry", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:ScheduleEntry)
@@ -2277,7 +1889,8 @@ impl<'buf> ScheduleEntry<'buf> {
 }
 
 /// Forward reference coverage: A references B before B is declared.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ForwardRefA<'buf> {
   pub b: ForwardRefB<'buf>,
 }
@@ -2326,7 +1939,8 @@ impl<'buf> ForwardRefA<'buf> {
   // @@bebop_insertion_point(struct_scope:ForwardRefA)
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ForwardRefB<'buf> {
   pub value: borrow::Cow<'buf, str>,
 }
@@ -2377,12 +1991,13 @@ impl<'buf> ForwardRefB<'buf> {
 }
 
 /// Message with deprecated fields that should still round-trip on the wire.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct DeprecatedFieldsMessage<'buf> {
   pub current_name: option::Option<borrow::Cow<'buf, str>>,
-  #[deprecated(note = "legacy wire compatibility")]
+#[deprecated(note = "legacy wire compatibility")]
   pub legacy_name: option::Option<borrow::Cow<'buf, str>>,
-  #[deprecated]
+#[deprecated]
   pub legacy_enabled: option::Option<bool>,
 }
 
@@ -2391,9 +2006,7 @@ pub type DeprecatedFieldsMessageOwned = DeprecatedFieldsMessage<'static>;
 impl<'buf> DeprecatedFieldsMessage<'buf> {
   pub fn into_owned(self) -> DeprecatedFieldsMessageOwned {
     DeprecatedFieldsMessage {
-      current_name: self
-        .current_name
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      current_name: self.current_name.map(|v| borrow::Cow::Owned(v.into_owned())),
       legacy_name: self.legacy_name.map(|v| borrow::Cow::Owned(v.into_owned())),
       legacy_enabled: self.legacy_enabled,
     }
@@ -2451,37 +2064,12 @@ impl<'buf> bebop::BebopDecode<'buf> for DeprecatedFieldsMessage<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.current_name = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("DeprecatedFieldsMessage", "current_name")?,
-          ))
-        }
-        2 => {
-          msg.legacy_name = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("DeprecatedFieldsMessage", "legacy_name")?,
-          ))
-        }
-        3 => {
-          msg.legacy_enabled = option::Option::Some(
-            reader
-              .read_bool()
-              .for_field("DeprecatedFieldsMessage", "legacy_enabled")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "DeprecatedFieldsMessage",
-            tag,
-          });
-        }
+        1 => msg.current_name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DeprecatedFieldsMessage", "current_name")?)),
+        2 => msg.legacy_name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DeprecatedFieldsMessage", "legacy_name")?)),
+        3 => msg.legacy_enabled = option::Option::Some(reader.read_bool().for_field("DeprecatedFieldsMessage", "legacy_enabled")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "DeprecatedFieldsMessage", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:DeprecatedFieldsMessage)
@@ -2506,7 +2094,8 @@ impl<'buf> DeprecatedFieldsMessage<'buf> {
 }
 
 /// Integer-key map coverage.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct IntegerKeyMaps<'buf> {
   pub labels_by_id: option::Option<bebop::HashMap<u32, borrow::Cow<'buf, str>>>,
   pub flags_by_id: option::Option<bebop::HashMap<i64, bool>>,
@@ -2517,11 +2106,7 @@ pub type IntegerKeyMapsOwned = IntegerKeyMaps<'static>;
 impl<'buf> IntegerKeyMaps<'buf> {
   pub fn into_owned(self) -> IntegerKeyMapsOwned {
     IntegerKeyMaps {
-      labels_by_id: self.labels_by_id.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| (_k, borrow::Cow::Owned(_v.into_owned())))
-          .collect()
-      }),
+      labels_by_id: self.labels_by_id.map(|v| v.into_iter().map(|(_k, _v)| (_k, borrow::Cow::Owned(_v.into_owned()))).collect()),
       flags_by_id: self.flags_by_id,
     }
   }
@@ -2538,17 +2123,11 @@ impl<'buf> bebop::BebopEncode for IntegerKeyMaps<'buf> {
     // normally. This behavior should be revisited once the spec intent is clarified.
     if let option::Option::Some(ref v) = self.labels_by_id {
       writer.write_tag(1);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_u32(*_k);
-        _w.write_string(&_v);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_u32(*_k); _w.write_string(&_v); });
     }
     if let option::Option::Some(ref v) = self.flags_by_id {
       writer.write_tag(2);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_i64(*_k);
-        _w.write_bool(*_v);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_i64(*_k); _w.write_bool(*_v); });
     }
     writer.write_end_marker();
     writer.fill_message_length(pos);
@@ -2558,14 +2137,10 @@ impl<'buf> bebop::BebopEncode for IntegerKeyMaps<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.labels_by_id {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        mem::size_of::<u32>() + bebop::wire_size::string_size(_v.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| mem::size_of::<u32>() + bebop::wire_size::string_size(_v.len())));
     }
     if let option::Option::Some(ref v) = self.flags_by_id {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        mem::size_of::<i64>() + mem::size_of::<bool>()
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| mem::size_of::<i64>() + mem::size_of::<bool>()));
     }
     size
   }
@@ -2581,35 +2156,11 @@ impl<'buf> bebop::BebopDecode<'buf> for IntegerKeyMaps<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.labels_by_id = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  _r.read_u32()?,
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                ))
-              })
-              .for_field("IntegerKeyMaps", "labels_by_id")?,
-          )
-        }
-        2 => {
-          msg.flags_by_id = option::Option::Some(
-            reader
-              .read_map(|_r| result::Result::Ok((_r.read_i64()?, _r.read_bool()?)))
-              .for_field("IntegerKeyMaps", "flags_by_id")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "IntegerKeyMaps",
-            tag,
-          });
-        }
+        1 => msg.labels_by_id = option::Option::Some(reader.read_map(|_r| result::Result::Ok((_r.read_u32()?, result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?))).for_field("IntegerKeyMaps", "labels_by_id")?),
+        2 => msg.flags_by_id = option::Option::Some(reader.read_map(|_r| result::Result::Ok((_r.read_i64()?, _r.read_bool()?))).for_field("IntegerKeyMaps", "flags_by_id")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "IntegerKeyMaps", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:IntegerKeyMaps)
@@ -2618,12 +2169,8 @@ impl<'buf> bebop::BebopDecode<'buf> for IntegerKeyMaps<'buf> {
 }
 
 impl<'buf> IntegerKeyMaps<'buf> {
-  pub fn with_labels_by_id(
-    mut self,
-    value: impl iter::IntoIterator<Item = (u32, impl convert::Into<borrow::Cow<'buf, str>>)>,
-  ) -> Self {
-    self.labels_by_id =
-      option::Option::Some(value.into_iter().map(|(_k, _v)| (_k, _v.into())).collect());
+  pub fn with_labels_by_id(mut self, value: impl iter::IntoIterator<Item = (u32, impl convert::Into<borrow::Cow<'buf, str>>)>) -> Self {
+    self.labels_by_id = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k, _v.into())).collect());
     self
   }
   pub fn with_flags_by_id(mut self, value: impl iter::IntoIterator<Item = (i64, bool)>) -> Self {
@@ -2634,7 +2181,8 @@ impl<'buf> IntegerKeyMaps<'buf> {
 }
 
 /// Nested type used by deep compound collections.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NestedLeaf<'buf> {
   pub label: borrow::Cow<'buf, str>,
 }
@@ -2685,14 +2233,10 @@ impl<'buf> NestedLeaf<'buf> {
 }
 
 /// Deeply nested map/array/defined-type composition.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct DeepNestedCollections<'buf> {
-  pub nested: option::Option<
-    bebop::HashMap<
-      borrow::Cow<'buf, str>,
-      vec::Vec<bebop::HashMap<borrow::Cow<'buf, str>, NestedLeaf<'buf>>>,
-    >,
-  >,
+  pub nested: option::Option<bebop::HashMap<borrow::Cow<'buf, str>, vec::Vec<bebop::HashMap<borrow::Cow<'buf, str>, NestedLeaf<'buf>>>>>,
 }
 
 pub type DeepNestedCollectionsOwned = DeepNestedCollections<'static>;
@@ -2700,22 +2244,7 @@ pub type DeepNestedCollectionsOwned = DeepNestedCollections<'static>;
 impl<'buf> DeepNestedCollections<'buf> {
   pub fn into_owned(self) -> DeepNestedCollectionsOwned {
     DeepNestedCollections {
-      nested: self.nested.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| {
-            (
-              borrow::Cow::Owned(_k.into_owned()),
-              _v.into_iter()
-                .map(|_e| {
-                  _e.into_iter()
-                    .map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned()))
-                    .collect()
-                })
-                .collect(),
-            )
-          })
-          .collect()
-      }),
+      nested: self.nested.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_iter().map(|_e| _e.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned())).collect()).collect())).collect()),
     }
   }
 }
@@ -2731,15 +2260,7 @@ impl<'buf> bebop::BebopEncode for DeepNestedCollections<'buf> {
     // normally. This behavior should be revisited once the spec intent is clarified.
     if let option::Option::Some(ref v) = self.nested {
       writer.write_tag(1);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _w.write_array(&_v, |_w, _el| {
-          _w.write_map(&_el, |_w, _k, _v| {
-            _w.write_string(&_k);
-            _v.encode(_w);
-          })
-        });
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _w.write_array(&_v, |_w, _el| { _w.write_map(&_el, |_w, _k, _v| { _w.write_string(&_k); _v.encode(_w); }) }); });
     }
     writer.write_end_marker();
     writer.fill_message_length(pos);
@@ -2749,14 +2270,7 @@ impl<'buf> bebop::BebopEncode for DeepNestedCollections<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.nested {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len())
-          + bebop::wire_size::array_size(_v, |_el| {
-            bebop::wire_size::map_size(_el, |_k, _v| {
-              bebop::wire_size::string_size(_k.len()) + _v.encoded_size()
-            })
-          })
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + bebop::wire_size::array_size(_v, |_el| bebop::wire_size::map_size(_el, |_k, _v| bebop::wire_size::string_size(_k.len()) + _v.encoded_size()))));
     }
     size
   }
@@ -2772,35 +2286,10 @@ impl<'buf> bebop::BebopDecode<'buf> for DeepNestedCollections<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.nested = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  _r.read_array(|_r| {
-                    _r.read_map(|_r| {
-                      result::Result::Ok((
-                        result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                        NestedLeaf::decode(_r)?,
-                      ))
-                    })
-                  })?,
-                ))
-              })
-              .for_field("DeepNestedCollections", "nested")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "DeepNestedCollections",
-            tag,
-          });
-        }
+        1 => msg.nested = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, _r.read_array(|_r| _r.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, NestedLeaf::decode(_r)?))))?))).for_field("DeepNestedCollections", "nested")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "DeepNestedCollections", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:DeepNestedCollections)
@@ -2809,15 +2298,7 @@ impl<'buf> bebop::BebopDecode<'buf> for DeepNestedCollections<'buf> {
 }
 
 impl<'buf> DeepNestedCollections<'buf> {
-  pub fn with_nested(
-    mut self,
-    value: impl iter::IntoIterator<
-      Item = (
-        impl convert::Into<borrow::Cow<'buf, str>>,
-        vec::Vec<bebop::HashMap<borrow::Cow<'buf, str>, NestedLeaf<'buf>>>,
-      ),
-    >,
-  ) -> Self {
+  pub fn with_nested(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, vec::Vec<bebop::HashMap<borrow::Cow<'buf, str>, NestedLeaf<'buf>>>)>) -> Self {
     self.nested = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v)).collect());
     self
   }
@@ -2825,7 +2306,8 @@ impl<'buf> DeepNestedCollections<'buf> {
 }
 
 /// Struct with nested byte array (byte[][]).
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ByteMatrix<'buf> {
   pub rows: vec::Vec<bebop::BebopBytes<'buf>>,
 }
@@ -2833,9 +2315,7 @@ pub struct ByteMatrix<'buf> {
 pub type ByteMatrixOwned = ByteMatrix<'static>;
 
 impl<'buf> ByteMatrix<'buf> {
-  pub fn new(
-    rows: impl iter::IntoIterator<Item = impl convert::Into<bebop::BebopBytes<'buf>>>,
-  ) -> Self {
+  pub fn new(rows: impl iter::IntoIterator<Item = impl convert::Into<bebop::BebopBytes<'buf>>>) -> Self {
     let rows = rows.into_iter().map(|_e| _e.into()).collect();
     Self { rows }
   }
@@ -2852,15 +2332,13 @@ impl<'buf> ByteMatrix<'buf> {
 impl<'buf> bebop::BebopEncode for ByteMatrix<'buf> {
   fn encode(&self, writer: &mut bebop::BebopWriter) {
     // @@bebop_insertion_point(encode_start:ByteMatrix)
-    writer.write_array(&self.rows, |_w, _el| _w.write_byte_array(&_el));
+    writer.write_array(&self.rows, |_w, _el| { _w.write_byte_array(&_el) });
     // @@bebop_insertion_point(encode_end:ByteMatrix)
   }
 
   fn encoded_size(&self) -> usize {
     let mut size = 0;
-    size += bebop::wire_size::array_size(&self.rows, |_el| {
-      bebop::wire_size::byte_array_size(_el.len())
-    });
+    size += bebop::wire_size::array_size(&self.rows, |_el| bebop::wire_size::byte_array_size(_el.len()));
     size
   }
 }
@@ -2869,9 +2347,7 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteMatrix<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:ByteMatrix)
-    let rows = reader
-      .read_array(|_r| result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?)))
-      .for_field("ByteMatrix", "rows")?;
+    let rows = reader.read_array(|_r| result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))).for_field("ByteMatrix", "rows")?;
     // @@bebop_insertion_point(decode_end:ByteMatrix)
     result::Result::Ok(ByteMatrix { rows })
   }
@@ -2882,7 +2358,8 @@ impl<'buf> ByteMatrix<'buf> {
 }
 
 /// Struct with map containing byte array values.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ByteTagMap<'buf> {
   pub entries: bebop::HashMap<borrow::Cow<'buf, str>, bebop::BebopBytes<'buf>>,
 }
@@ -2890,18 +2367,8 @@ pub struct ByteTagMap<'buf> {
 pub type ByteTagMapOwned = ByteTagMap<'static>;
 
 impl<'buf> ByteTagMap<'buf> {
-  pub fn new(
-    entries: impl iter::IntoIterator<
-      Item = (
-        impl convert::Into<borrow::Cow<'buf, str>>,
-        impl convert::Into<bebop::BebopBytes<'buf>>,
-      ),
-    >,
-  ) -> Self {
-    let entries = entries
-      .into_iter()
-      .map(|(_k, _v)| (_k.into(), _v.into()))
-      .collect();
+  pub fn new(entries: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, impl convert::Into<bebop::BebopBytes<'buf>>)>) -> Self {
+    let entries = entries.into_iter().map(|(_k, _v)| (_k.into(), _v.into())).collect();
     Self { entries }
   }
 }
@@ -2909,11 +2376,7 @@ impl<'buf> ByteTagMap<'buf> {
 impl<'buf> ByteTagMap<'buf> {
   pub fn into_owned(self) -> ByteTagMapOwned {
     ByteTagMap {
-      entries: self
-        .entries
-        .into_iter()
-        .map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned()))
-        .collect(),
+      entries: self.entries.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned())).collect(),
     }
   }
 }
@@ -2921,18 +2384,13 @@ impl<'buf> ByteTagMap<'buf> {
 impl<'buf> bebop::BebopEncode for ByteTagMap<'buf> {
   fn encode(&self, writer: &mut bebop::BebopWriter) {
     // @@bebop_insertion_point(encode_start:ByteTagMap)
-    writer.write_map(&self.entries, |_w, _k, _v| {
-      _w.write_string(&_k);
-      _w.write_byte_array(&_v);
-    });
+    writer.write_map(&self.entries, |_w, _k, _v| { _w.write_string(&_k); _w.write_byte_array(&_v); });
     // @@bebop_insertion_point(encode_end:ByteTagMap)
   }
 
   fn encoded_size(&self) -> usize {
     let mut size = 0;
-    size += bebop::wire_size::map_size(&self.entries, |_k, _v| {
-      bebop::wire_size::string_size(_k.len()) + bebop::wire_size::byte_array_size(_v.len())
-    });
+    size += bebop::wire_size::map_size(&self.entries, |_k, _v| bebop::wire_size::string_size(_k.len()) + bebop::wire_size::byte_array_size(_v.len()));
     size
   }
 }
@@ -2941,14 +2399,7 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteTagMap<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:ByteTagMap)
-    let entries = reader
-      .read_map(|_r| {
-        result::Result::Ok((
-          result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-          result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))?,
-        ))
-      })
-      .for_field("ByteTagMap", "entries")?;
+    let entries = reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))?))).for_field("ByteTagMap", "entries")?;
     // @@bebop_insertion_point(decode_end:ByteTagMap)
     result::Result::Ok(ByteTagMap { entries })
   }
@@ -2959,7 +2410,8 @@ impl<'buf> ByteTagMap<'buf> {
 }
 
 /// Message with byte array field — tests Option<BebopBytes> serde.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct ByteArrayMessage<'buf> {
   pub label: option::Option<borrow::Cow<'buf, str>>,
   pub payload: option::Option<bebop::BebopBytes<'buf>>,
@@ -3020,28 +2472,11 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteArrayMessage<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.label = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("ByteArrayMessage", "label")?,
-          ))
-        }
-        2 => {
-          msg.payload = option::Option::Some(bebop::BebopBytes::borrowed(
-            reader
-              .read_byte_slice()
-              .for_field("ByteArrayMessage", "payload")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "ByteArrayMessage",
-            tag,
-          });
-        }
+        1 => msg.label = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("ByteArrayMessage", "label")?)),
+        2 => msg.payload = option::Option::Some(bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field("ByteArrayMessage", "payload")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "ByteArrayMessage", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:ByteArrayMessage)
@@ -3062,7 +2497,8 @@ impl<'buf> ByteArrayMessage<'buf> {
 }
 
 /// Message with nested byte arrays and maps.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ByteCollectionMessage<'buf> {
   pub matrix: option::Option<vec::Vec<bebop::BebopBytes<'buf>>>,
   pub tagged: option::Option<bebop::HashMap<borrow::Cow<'buf, str>, bebop::BebopBytes<'buf>>>,
@@ -3073,14 +2509,8 @@ pub type ByteCollectionMessageOwned = ByteCollectionMessage<'static>;
 impl<'buf> ByteCollectionMessage<'buf> {
   pub fn into_owned(self) -> ByteCollectionMessageOwned {
     ByteCollectionMessage {
-      matrix: self
-        .matrix
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
-      tagged: self.tagged.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned()))
-          .collect()
-      }),
+      matrix: self.matrix.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      tagged: self.tagged.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned())).collect()),
     }
   }
 }
@@ -3096,14 +2526,11 @@ impl<'buf> bebop::BebopEncode for ByteCollectionMessage<'buf> {
     // normally. This behavior should be revisited once the spec intent is clarified.
     if let option::Option::Some(ref v) = self.matrix {
       writer.write_tag(1);
-      writer.write_array(&v, |_w, _el| _w.write_byte_array(&_el));
+      writer.write_array(&v, |_w, _el| { _w.write_byte_array(&_el) });
     }
     if let option::Option::Some(ref v) = self.tagged {
       writer.write_tag(2);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _w.write_byte_array(&_v);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _w.write_byte_array(&_v); });
     }
     writer.write_end_marker();
     writer.fill_message_length(pos);
@@ -3113,14 +2540,10 @@ impl<'buf> bebop::BebopEncode for ByteCollectionMessage<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.matrix {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| {
-        bebop::wire_size::byte_array_size(_el.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| bebop::wire_size::byte_array_size(_el.len())));
     }
     if let option::Option::Some(ref v) = self.tagged {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len()) + bebop::wire_size::byte_array_size(_v.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + bebop::wire_size::byte_array_size(_v.len())));
     }
     size
   }
@@ -3136,37 +2559,11 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteCollectionMessage<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.matrix = option::Option::Some(
-            reader
-              .read_array(|_r| {
-                result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))
-              })
-              .for_field("ByteCollectionMessage", "matrix")?,
-          )
-        }
-        2 => {
-          msg.tagged = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))?,
-                ))
-              })
-              .for_field("ByteCollectionMessage", "tagged")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "ByteCollectionMessage",
-            tag,
-          });
-        }
+        1 => msg.matrix = option::Option::Some(reader.read_array(|_r| result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))).for_field("ByteCollectionMessage", "matrix")?),
+        2 => msg.tagged = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, result::Result::Ok(bebop::BebopBytes::borrowed(_r.read_byte_slice()?))?))).for_field("ByteCollectionMessage", "tagged")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "ByteCollectionMessage", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:ByteCollectionMessage)
@@ -3175,35 +2572,20 @@ impl<'buf> bebop::BebopDecode<'buf> for ByteCollectionMessage<'buf> {
 }
 
 impl<'buf> ByteCollectionMessage<'buf> {
-  pub fn with_matrix(
-    mut self,
-    value: impl iter::IntoIterator<Item = impl convert::Into<bebop::BebopBytes<'buf>>>,
-  ) -> Self {
+  pub fn with_matrix(mut self, value: impl iter::IntoIterator<Item = impl convert::Into<bebop::BebopBytes<'buf>>>) -> Self {
     self.matrix = option::Option::Some(value.into_iter().map(|_e| _e.into()).collect());
     self
   }
-  pub fn with_tagged(
-    mut self,
-    value: impl iter::IntoIterator<
-      Item = (
-        impl convert::Into<borrow::Cow<'buf, str>>,
-        impl convert::Into<bebop::BebopBytes<'buf>>,
-      ),
-    >,
-  ) -> Self {
-    self.tagged = option::Option::Some(
-      value
-        .into_iter()
-        .map(|(_k, _v)| (_k.into(), _v.into()))
-        .collect(),
-    );
+  pub fn with_tagged(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, impl convert::Into<bebop::BebopBytes<'buf>>)>) -> Self {
+    self.tagged = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v.into())).collect());
     self
   }
   // @@bebop_insertion_point(message_scope:ByteCollectionMessage)
 }
 
 /// Struct with a UUID field for serde round-trip testing.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct UuidHolder<'buf> {
   pub id: bebop::Uuid,
   pub label: borrow::Cow<'buf, str>,
@@ -3212,7 +2594,10 @@ pub struct UuidHolder<'buf> {
 pub type UuidHolderOwned = UuidHolder<'static>;
 
 impl<'buf> UuidHolder<'buf> {
-  pub fn new(id: bebop::Uuid, label: impl convert::Into<borrow::Cow<'buf, str>>) -> Self {
+  pub fn new(
+    id: bebop::Uuid,
+    label: impl convert::Into<borrow::Cow<'buf, str>>,
+  ) -> Self {
     let label = label.into();
     Self { id, label }
   }

--- a/plugins/rust/integration-tests/tests/integration.rs
+++ b/plugins/rust/integration-tests/tests/integration.rs
@@ -1875,3 +1875,104 @@ fn fc_flags_unknown_bits_round_trip() {
   let decoded = FlexPermissions::from_bytes(&bytes).unwrap();
   assert_eq!(decoded.bits(), 129); // 1 | 128
 }
+
+// ═══════════════════════════════════════════════════════════════
+// DecodeError field context (issue #7)
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn decode_error_invalid_utf8_reports_type_and_field() {
+  // Construct a valid wire prefix but corrupt UTF-8 bytes for the `name` field.
+  // Person wire format: [u32 len][utf8 bytes][NUL][u32 age]
+  let mut buf = Vec::new();
+  buf.extend_from_slice(&2u32.to_le_bytes()); // length = 2
+  buf.push(0xFF); // invalid UTF-8 byte
+  buf.push(0xFE); // invalid UTF-8 byte
+  buf.push(0x00); // NUL terminator
+  buf.extend_from_slice(&30u32.to_le_bytes()); // age = 30
+
+  let err = Person::from_bytes(&buf).unwrap_err();
+  let msg = err.to_string();
+  assert!(
+    msg.contains("Person"),
+    "expected type name 'Person' in error message: {msg}"
+  );
+  assert!(
+    msg.contains("name"),
+    "expected field name 'name' in error message: {msg}"
+  );
+  assert!(
+    msg.contains("utf-8"),
+    "expected 'utf-8' in error message: {msg}"
+  );
+  // Exact format: "invalid utf-8 in Person.name"
+  assert_eq!(msg, "invalid utf-8 in Person.name");
+}
+
+#[test]
+fn decode_error_unexpected_eof_reports_type_and_field() {
+  // Truncated Person: valid name field, but age is only 2 bytes instead of 4.
+  let mut buf = Vec::new();
+  buf.extend_from_slice(&5u32.to_le_bytes()); // name length = 5
+  buf.extend_from_slice(b"Alice"); // name bytes
+  buf.push(0x00); // NUL terminator
+  buf.extend_from_slice(&[0x1E, 0x00]); // only 2 bytes of the 4-byte age
+
+  let err = Person::from_bytes(&buf).unwrap_err();
+  let msg = err.to_string();
+  assert!(
+    msg.contains("Person"),
+    "expected type name 'Person' in error message: {msg}"
+  );
+  assert!(
+    msg.contains("age"),
+    "expected field name 'age' in error message: {msg}"
+  );
+  // Exact format: "unexpected eof in Person.age: needed 4 bytes, 2 available"
+  assert_eq!(
+    msg,
+    "unexpected eof in Person.age: needed 4 bytes, 2 available"
+  );
+}
+
+#[test]
+fn decode_error_message_field_reports_type_and_field() {
+  // Truncated UserProfile message: valid wire header, but email field has bad UTF-8.
+  // Message wire format: [u32 body_len] [tag u8] [field data] ... [0x00]
+  // We'll encode a real message first and then corrupt the email field bytes.
+  let profile = UserProfile::default()
+    .with_display_name("Alice")
+    .with_email("alice@example.com");
+  let mut bytes = profile.to_bytes();
+
+  // Find the email field bytes and corrupt them.
+  // Tag 2 = email. Find `\x02` followed by the encoded string.
+  // The display_name tag (1) comes first. We need to locate tag 2.
+  if let Some(pos) = bytes.windows(1).position(|w| w[0] == 2) {
+    // pos points to the tag byte for field 2 (email).
+    // The string length is at pos+1 (u32 le), string bytes start at pos+5.
+    let str_start = pos + 1 + 4; // skip tag + u32 length
+    if str_start < bytes.len() {
+      bytes[str_start] = 0xFF; // corrupt first byte of email string
+    }
+    let err = UserProfile::from_bytes(&bytes).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+      msg.contains("UserProfile"),
+      "expected 'UserProfile' in error: {msg}"
+    );
+    assert!(msg.contains("email"), "expected 'email' in error: {msg}");
+    assert!(msg.contains("utf-8"), "expected 'utf-8' in error: {msg}");
+  }
+}
+
+#[test]
+fn decode_error_without_context_still_works() {
+  // An error from a decode path that doesn't go through generated code
+  // (e.g., truncated message length header) should still display gracefully.
+  let buf = [0x01u8]; // only 1 byte — not enough for the u32 message length
+  let err = UserProfile::from_bytes(&buf).unwrap_err();
+  let msg = err.to_string();
+  // Without field context, should fall back to the contextless message format.
+  assert!(msg.contains("unexpected eof"), "expected eof error: {msg}");
+}

--- a/plugins/rust/integration-tests/tests/integration.rs
+++ b/plugins/rust/integration-tests/tests/integration.rs
@@ -1946,15 +1946,22 @@ fn decode_error_message_field_reports_type_and_field() {
   let mut bytes = profile.to_bytes();
 
   // Find the email field bytes and corrupt them.
-  // Tag 2 = email. Find `\x02` followed by the encoded string.
-  // The display_name tag (1) comes first. We need to locate tag 2.
-  let pos = bytes
-    .iter()
-    .position(|&b| b == 2)
-    .expect("email tag byte (0x02) not found in encoded message");
-  // pos points to the tag byte for field 2 (email).
-  // The string length is at pos+1 (u32 le), string bytes start at pos+5.
-  let str_start = pos + 1 + 4; // skip tag + u32 length
+  // Message layout: [u32 body_len][body...]
+  // Body for this specific message (only display_name and email set):
+  //   [tag1=0x01][u32 display_name_len]["Alice"][NUL]
+  //   [tag2=0x02][u32 email_len]["alice@example.com"][NUL]
+  //   [0x00 terminator]
+  // Compute the email string's start offset directly rather than scanning for
+  // a 0x02 byte that could appear in unrelated parts of the encoding.
+  let display_name_bytes = b"Alice";
+  // 4 bytes body_len + 1 byte tag1 + 4 bytes u32 len + display_name + NUL
+  let email_tag_pos = 4 + 1 + 4 + display_name_bytes.len() + 1;
+  assert_eq!(
+    bytes[email_tag_pos], 2,
+    "expected email tag (0x02) at computed offset {email_tag_pos}"
+  );
+  // skip tag2 + u32 email_len to reach the first byte of email string data
+  let str_start = email_tag_pos + 1 + 4;
   assert!(
     str_start < bytes.len(),
     "str_start {str_start} out of bounds (len={})",

--- a/plugins/rust/integration-tests/tests/integration.rs
+++ b/plugins/rust/integration-tests/tests/integration.rs
@@ -1948,22 +1948,27 @@ fn decode_error_message_field_reports_type_and_field() {
   // Find the email field bytes and corrupt them.
   // Tag 2 = email. Find `\x02` followed by the encoded string.
   // The display_name tag (1) comes first. We need to locate tag 2.
-  if let Some(pos) = bytes.windows(1).position(|w| w[0] == 2) {
-    // pos points to the tag byte for field 2 (email).
-    // The string length is at pos+1 (u32 le), string bytes start at pos+5.
-    let str_start = pos + 1 + 4; // skip tag + u32 length
-    if str_start < bytes.len() {
-      bytes[str_start] = 0xFF; // corrupt first byte of email string
-    }
-    let err = UserProfile::from_bytes(&bytes).unwrap_err();
-    let msg = err.to_string();
-    assert!(
-      msg.contains("UserProfile"),
-      "expected 'UserProfile' in error: {msg}"
-    );
-    assert!(msg.contains("email"), "expected 'email' in error: {msg}");
-    assert!(msg.contains("utf-8"), "expected 'utf-8' in error: {msg}");
-  }
+  let pos = bytes
+    .iter()
+    .position(|&b| b == 2)
+    .expect("email tag byte (0x02) not found in encoded message");
+  // pos points to the tag byte for field 2 (email).
+  // The string length is at pos+1 (u32 le), string bytes start at pos+5.
+  let str_start = pos + 1 + 4; // skip tag + u32 length
+  assert!(
+    str_start < bytes.len(),
+    "str_start {str_start} out of bounds (len={})",
+    bytes.len()
+  );
+  bytes[str_start] = 0xFF; // corrupt first byte of email string
+  let err = UserProfile::from_bytes(&bytes).unwrap_err();
+  let msg = err.to_string();
+  assert!(
+    msg.contains("UserProfile"),
+    "expected 'UserProfile' in error: {msg}"
+  );
+  assert!(msg.contains("email"), "expected 'email' in error: {msg}");
+  assert!(msg.contains("utf-8"), "expected 'utf-8' in error: {msg}");
 }
 
 #[test]

--- a/plugins/rust/runtime/src/error.rs
+++ b/plugins/rust/runtime/src/error.rs
@@ -49,6 +49,10 @@ impl DecodeError {
   /// through nested decode calls. Outer decode frames calling `.for_field()` provide
   /// a fallback in case no inner context was set.
   pub fn with_context(self, type_name: &'static str, field_name: &'static str) -> Self {
+    debug_assert!(
+      !type_name.is_empty() && !field_name.is_empty(),
+      "with_context: both type_name and field_name must be non-empty"
+    );
     match self {
       DecodeError::UnexpectedEof {
         needed,
@@ -109,7 +113,7 @@ impl fmt::Display for DecodeError {
         type_name,
         field_name,
       } => {
-        if type_name.is_empty() {
+        if type_name.is_empty() || field_name.is_empty() {
           write!(
             f,
             "unexpected eof: needed {} bytes, {} available",
@@ -127,7 +131,7 @@ impl fmt::Display for DecodeError {
         type_name,
         field_name,
       } => {
-        if type_name.is_empty() {
+        if type_name.is_empty() || field_name.is_empty() {
           write!(f, "invalid utf-8 in string")
         } else {
           write!(f, "invalid utf-8 in {}.{}", type_name, field_name)

--- a/plugins/rust/runtime/src/error.rs
+++ b/plugins/rust/runtime/src/error.rs
@@ -6,16 +6,16 @@ pub enum DecodeError {
   UnexpectedEof {
     needed: usize,
     available: usize,
-    /// The type being decoded when the EOF occurred. Empty string if not yet set.
-    type_name: &'static str,
-    /// The field being decoded when the EOF occurred. Empty string if not yet set.
-    field_name: &'static str,
+    /// The type being decoded when the EOF occurred.
+    type_name: Option<&'static str>,
+    /// The field being decoded when the EOF occurred.
+    field_name: Option<&'static str>,
   },
   InvalidUtf8 {
-    /// The type being decoded when the invalid UTF-8 was found. Empty string if not yet set.
-    type_name: &'static str,
-    /// The field being decoded when the invalid UTF-8 was found. Empty string if not yet set.
-    field_name: &'static str,
+    /// The type being decoded when the invalid UTF-8 was found.
+    type_name: Option<&'static str>,
+    /// The field being decoded when the invalid UTF-8 was found.
+    field_name: Option<&'static str>,
   },
   InvalidEnum {
     type_name: &'static str,
@@ -42,12 +42,11 @@ impl DecodeError {
   /// Enrich a contextless error variant with type/field context.
   ///
   /// Only enriches [`DecodeError::UnexpectedEof`] and [`DecodeError::InvalidUtf8`] when
-  /// they have not already been enriched (i.e., `type_name` is empty). All other
+  /// they have not already been enriched (i.e., `type_name` is `None`). All other
   /// variants, and already-enriched contextless variants, pass through unchanged.
   ///
   /// This means the **innermost** `.for_field()` call wins when errors propagate
-  /// through nested decode calls. Outer decode frames calling `.for_field()` provide
-  /// a fallback in case no inner context was set.
+  /// through nested decode calls.
   pub fn with_context(self, type_name: &'static str, field_name: &'static str) -> Self {
     debug_assert!(
       !type_name.is_empty() && !field_name.is_empty(),
@@ -57,17 +56,19 @@ impl DecodeError {
       DecodeError::UnexpectedEof {
         needed,
         available,
-        type_name: "",
+        type_name: None,
         ..
       } => DecodeError::UnexpectedEof {
         needed,
         available,
-        type_name,
-        field_name,
+        type_name: Some(type_name),
+        field_name: Some(field_name),
       },
-      DecodeError::InvalidUtf8 { type_name: "", .. } => DecodeError::InvalidUtf8 {
-        type_name,
-        field_name,
+      DecodeError::InvalidUtf8 {
+        type_name: None, ..
+      } => DecodeError::InvalidUtf8 {
+        type_name: Some(type_name),
+        field_name: Some(field_name),
       },
       other => other,
     }
@@ -82,9 +83,6 @@ impl DecodeError {
 /// errors report exactly where in the schema the failure occurred.
 ///
 /// Inspired by the [`anyhow::Context`](https://docs.rs/anyhow/latest/anyhow/trait.Context.html) pattern.
-/// Only enriches [`DecodeError::UnexpectedEof`] and [`DecodeError::InvalidUtf8`]
-/// (the contextless variants); all others pass through unchanged. The innermost
-/// `.for_field()` call wins — outer callers add context only when none exists.
 pub trait DecodeContext<T> {
   fn for_field(
     self,
@@ -110,33 +108,29 @@ impl fmt::Display for DecodeError {
       Self::UnexpectedEof {
         needed,
         available,
-        type_name,
-        field_name,
+        type_name: Some(t),
+        field_name: Some(fld),
       } => {
-        if type_name.is_empty() || field_name.is_empty() {
-          write!(
-            f,
-            "unexpected eof: needed {} bytes, {} available",
-            needed, available
-          )
-        } else {
-          write!(
-            f,
-            "unexpected eof in {}.{}: needed {} bytes, {} available",
-            type_name, field_name, needed, available
-          )
-        }
+        write!(
+          f,
+          "unexpected eof in {}.{}: needed {} bytes, {} available",
+          t, fld, needed, available
+        )
+      }
+      Self::UnexpectedEof {
+        needed, available, ..
+      } => {
+        write!(
+          f,
+          "unexpected eof: needed {} bytes, {} available",
+          needed, available
+        )
       }
       Self::InvalidUtf8 {
-        type_name,
-        field_name,
-      } => {
-        if type_name.is_empty() || field_name.is_empty() {
-          write!(f, "invalid utf-8 in string")
-        } else {
-          write!(f, "invalid utf-8 in {}.{}", type_name, field_name)
-        }
-      }
+        type_name: Some(t),
+        field_name: Some(fld),
+      } => write!(f, "invalid utf-8 in {}.{}", t, fld),
+      Self::InvalidUtf8 { .. } => write!(f, "invalid utf-8 in string"),
       Self::InvalidEnum { type_name, value } => {
         write!(f, "invalid {} value: {}", type_name, value)
       }

--- a/plugins/rust/runtime/src/error.rs
+++ b/plugins/rust/runtime/src/error.rs
@@ -6,8 +6,17 @@ pub enum DecodeError {
   UnexpectedEof {
     needed: usize,
     available: usize,
+    /// The type being decoded when the EOF occurred. Empty string if not yet set.
+    type_name: &'static str,
+    /// The field being decoded when the EOF occurred. Empty string if not yet set.
+    field_name: &'static str,
   },
-  InvalidUtf8,
+  InvalidUtf8 {
+    /// The type being decoded when the invalid UTF-8 was found. Empty string if not yet set.
+    type_name: &'static str,
+    /// The field being decoded when the invalid UTF-8 was found. Empty string if not yet set.
+    field_name: &'static str,
+  },
   InvalidEnum {
     type_name: &'static str,
     value: u64,
@@ -29,17 +38,101 @@ pub enum DecodeError {
   },
 }
 
+impl DecodeError {
+  /// Enrich a contextless error variant with type/field context.
+  ///
+  /// Only enriches [`DecodeError::UnexpectedEof`] and [`DecodeError::InvalidUtf8`] when
+  /// they have not already been enriched (i.e., `type_name` is empty). All other
+  /// variants, and already-enriched contextless variants, pass through unchanged.
+  ///
+  /// This means the **innermost** `.for_field()` call wins when errors propagate
+  /// through nested decode calls. Outer decode frames calling `.for_field()` provide
+  /// a fallback in case no inner context was set.
+  pub fn with_context(self, type_name: &'static str, field_name: &'static str) -> Self {
+    match self {
+      DecodeError::UnexpectedEof {
+        needed,
+        available,
+        type_name: "",
+        ..
+      } => DecodeError::UnexpectedEof {
+        needed,
+        available,
+        type_name,
+        field_name,
+      },
+      DecodeError::InvalidUtf8 { type_name: "", .. } => DecodeError::InvalidUtf8 {
+        type_name,
+        field_name,
+      },
+      other => other,
+    }
+  }
+}
+
+/// Extension trait for adding field context to [`DecodeError`] results.
+///
+/// Provides the `.for_field(type_name, field_name)` method on
+/// `Result<T, DecodeError>`. In generated code, every field read is
+/// wrapped with `.for_field("TypeName", "field_name")` so that decode
+/// errors report exactly where in the schema the failure occurred.
+///
+/// Inspired by the [`anyhow::Context`](https://docs.rs/anyhow/latest/anyhow/trait.Context.html) pattern.
+/// Only enriches [`DecodeError::UnexpectedEof`] and [`DecodeError::InvalidUtf8`]
+/// (the contextless variants); all others pass through unchanged. The innermost
+/// `.for_field()` call wins — outer callers add context only when none exists.
+pub trait DecodeContext<T> {
+  fn for_field(
+    self,
+    type_name: &'static str,
+    field_name: &'static str,
+  ) -> core::result::Result<T, DecodeError>;
+}
+
+impl<T> DecodeContext<T> for core::result::Result<T, DecodeError> {
+  #[inline]
+  fn for_field(
+    self,
+    type_name: &'static str,
+    field_name: &'static str,
+  ) -> core::result::Result<T, DecodeError> {
+    self.map_err(|e| e.with_context(type_name, field_name))
+  }
+}
+
 impl fmt::Display for DecodeError {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     match self {
-      Self::UnexpectedEof { needed, available } => {
-        write!(
-          f,
-          "unexpected eof: needed {} bytes, {} available",
-          needed, available
-        )
+      Self::UnexpectedEof {
+        needed,
+        available,
+        type_name,
+        field_name,
+      } => {
+        if type_name.is_empty() {
+          write!(
+            f,
+            "unexpected eof: needed {} bytes, {} available",
+            needed, available
+          )
+        } else {
+          write!(
+            f,
+            "unexpected eof in {}.{}: needed {} bytes, {} available",
+            type_name, field_name, needed, available
+          )
+        }
       }
-      Self::InvalidUtf8 => write!(f, "invalid utf-8 in string"),
+      Self::InvalidUtf8 {
+        type_name,
+        field_name,
+      } => {
+        if type_name.is_empty() {
+          write!(f, "invalid utf-8 in string")
+        } else {
+          write!(f, "invalid utf-8 in {}.{}", type_name, field_name)
+        }
+      }
       Self::InvalidEnum { type_name, value } => {
         write!(f, "invalid {} value: {}", type_name, value)
       }

--- a/plugins/rust/runtime/src/lib.rs
+++ b/plugins/rust/runtime/src/lib.rs
@@ -13,7 +13,7 @@ pub mod wire_size;
 mod writer;
 
 pub use bytes::BebopBytes;
-pub use error::DecodeError;
+pub use error::{DecodeContext, DecodeError};
 #[cfg(feature = "half")]
 pub use half::bf16;
 #[cfg(feature = "half")]

--- a/plugins/rust/runtime/src/reader.rs
+++ b/plugins/rust/runtime/src/reader.rs
@@ -13,7 +13,10 @@ use crate::HashMap;
 /// Returns the validated `&str` directly, avoiding `from_utf8_unchecked`.
 #[inline]
 fn validate_utf8(bytes: &[u8]) -> core::result::Result<&str, DecodeError> {
-  simdutf8::basic::from_utf8(bytes).map_err(|_| DecodeError::InvalidUtf8)
+  simdutf8::basic::from_utf8(bytes).map_err(|_| DecodeError::InvalidUtf8 {
+    type_name: "",
+    field_name: "",
+  })
 }
 
 type Result<T> = core::result::Result<T, DecodeError>;
@@ -61,6 +64,8 @@ impl<'a> BebopReader<'a> {
       Err(DecodeError::UnexpectedEof {
         needed: count,
         available: self.remaining(),
+        type_name: "",
+        field_name: "",
       })
     }
   }
@@ -176,6 +181,8 @@ impl<'a> BebopReader<'a> {
     let total = len.checked_add(1).ok_or(DecodeError::UnexpectedEof {
       needed: usize::MAX,
       available: self.remaining(),
+      type_name: "",
+      field_name: "",
     })?;
     self.ensure(total)?; // string bytes + NUL
     let str_bytes = &self.buf[self.pos..self.pos + len];
@@ -245,6 +252,8 @@ impl<'a> BebopReader<'a> {
       return Err(DecodeError::UnexpectedEof {
         needed: count,
         available: self.remaining(),
+        type_name: "",
+        field_name: "",
       });
     }
     let mut items: Vec<T> = Vec::new();
@@ -298,6 +307,8 @@ impl<'a> BebopReader<'a> {
       .ok_or(DecodeError::UnexpectedEof {
         needed: usize::MAX,
         available: self.remaining(),
+        type_name: "",
+        field_name: "",
       })?;
     self.ensure(byte_len)?;
 
@@ -354,6 +365,8 @@ impl<'a> BebopReader<'a> {
       return Err(DecodeError::UnexpectedEof {
         needed: count.saturating_mul(2),
         available: self.remaining(),
+        type_name: "",
+        field_name: "",
       });
     }
     let mut map = HashMap::new();
@@ -411,6 +424,8 @@ impl<'a> BebopReader<'a> {
     let total = len.checked_add(1).ok_or(DecodeError::UnexpectedEof {
       needed: usize::MAX,
       available: self.remaining(),
+      type_name: "",
+      field_name: "",
     })?;
     self.ensure(total)?; // string bytes + NUL
     let str_bytes = &self.buf[self.pos..self.pos + len];

--- a/plugins/rust/runtime/src/reader.rs
+++ b/plugins/rust/runtime/src/reader.rs
@@ -14,8 +14,8 @@ use crate::HashMap;
 #[inline]
 fn validate_utf8(bytes: &[u8]) -> core::result::Result<&str, DecodeError> {
   simdutf8::basic::from_utf8(bytes).map_err(|_| DecodeError::InvalidUtf8 {
-    type_name: "",
-    field_name: "",
+    type_name: None,
+    field_name: None,
   })
 }
 
@@ -64,8 +64,8 @@ impl<'a> BebopReader<'a> {
       Err(DecodeError::UnexpectedEof {
         needed: count,
         available: self.remaining(),
-        type_name: "",
-        field_name: "",
+        type_name: None,
+        field_name: None,
       })
     }
   }
@@ -181,8 +181,8 @@ impl<'a> BebopReader<'a> {
     let total = len.checked_add(1).ok_or(DecodeError::UnexpectedEof {
       needed: usize::MAX,
       available: self.remaining(),
-      type_name: "",
-      field_name: "",
+      type_name: None,
+      field_name: None,
     })?;
     self.ensure(total)?; // string bytes + NUL
     let str_bytes = &self.buf[self.pos..self.pos + len];
@@ -252,8 +252,8 @@ impl<'a> BebopReader<'a> {
       return Err(DecodeError::UnexpectedEof {
         needed: count,
         available: self.remaining(),
-        type_name: "",
-        field_name: "",
+        type_name: None,
+        field_name: None,
       });
     }
     let mut items: Vec<T> = Vec::new();
@@ -307,8 +307,8 @@ impl<'a> BebopReader<'a> {
       .ok_or(DecodeError::UnexpectedEof {
         needed: usize::MAX,
         available: self.remaining(),
-        type_name: "",
-        field_name: "",
+        type_name: None,
+        field_name: None,
       })?;
     self.ensure(byte_len)?;
 
@@ -365,8 +365,8 @@ impl<'a> BebopReader<'a> {
       return Err(DecodeError::UnexpectedEof {
         needed: count.saturating_mul(2),
         available: self.remaining(),
-        type_name: "",
-        field_name: "",
+        type_name: None,
+        field_name: None,
       });
     }
     let mut map = HashMap::new();
@@ -424,8 +424,8 @@ impl<'a> BebopReader<'a> {
     let total = len.checked_add(1).ok_or(DecodeError::UnexpectedEof {
       needed: usize::MAX,
       available: self.remaining(),
-      type_name: "",
-      field_name: "",
+      type_name: None,
+      field_name: None,
     })?;
     self.ensure(total)?; // string bytes + NUL
     let str_bytes = &self.buf[self.pos..self.pos + len];

--- a/plugins/rust/src/generated/descriptor.rs
+++ b/plugins/rust/src/generated/descriptor.rs
@@ -90,18 +90,13 @@ impl convert::TryFrom<u8> for TypeKind {
       21 => result::Result::Ok(Self::FixedArray),
       22 => result::Result::Ok(Self::Map),
       23 => result::Result::Ok(Self::Defined),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "TypeKind",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "TypeKind", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<TypeKind> for u8 {
-  fn from(value: TypeKind) -> u8 {
-    value as u8
-  }
+  fn from(value: TypeKind) -> u8 { value as u8 }
 }
 
 impl TypeKind {
@@ -116,9 +111,7 @@ impl bebop::BebopEncode for TypeKind {
     // @@bebop_insertion_point(encode_end:TypeKind)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for TypeKind {
@@ -160,18 +153,13 @@ impl convert::TryFrom<u8> for DefinitionKind {
       5 => result::Result::Ok(Self::Service),
       6 => result::Result::Ok(Self::Const),
       7 => result::Result::Ok(Self::Decorator),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "DefinitionKind",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "DefinitionKind", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<DefinitionKind> for u8 {
-  fn from(value: DefinitionKind) -> u8 {
-    value as u8
-  }
+  fn from(value: DefinitionKind) -> u8 { value as u8 }
 }
 
 impl DefinitionKind {
@@ -186,9 +174,7 @@ impl bebop::BebopEncode for DefinitionKind {
     // @@bebop_insertion_point(encode_end:DefinitionKind)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for DefinitionKind {
@@ -228,18 +214,13 @@ impl convert::TryFrom<u8> for MethodType {
       2 => result::Result::Ok(Self::ServerStream),
       3 => result::Result::Ok(Self::ClientStream),
       4 => result::Result::Ok(Self::DuplexStream),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "MethodType",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "MethodType", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<MethodType> for u8 {
-  fn from(value: MethodType) -> u8 {
-    value as u8
-  }
+  fn from(value: MethodType) -> u8 { value as u8 }
 }
 
 impl MethodType {
@@ -254,9 +235,7 @@ impl bebop::BebopEncode for MethodType {
     // @@bebop_insertion_point(encode_end:MethodType)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for MethodType {
@@ -291,18 +270,13 @@ impl convert::TryFrom<u8> for Visibility {
       0 => result::Result::Ok(Self::Default),
       1 => result::Result::Ok(Self::Export),
       2 => result::Result::Ok(Self::Local),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "Visibility",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "Visibility", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<Visibility> for u8 {
-  fn from(value: Visibility) -> u8 {
-    value as u8
-  }
+  fn from(value: Visibility) -> u8 { value as u8 }
 }
 
 impl Visibility {
@@ -317,9 +291,7 @@ impl bebop::BebopEncode for Visibility {
     // @@bebop_insertion_point(encode_end:Visibility)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for Visibility {
@@ -361,18 +333,13 @@ impl convert::TryFrom<u8> for LiteralKind {
       6 => result::Result::Ok(Self::Bytes),
       7 => result::Result::Ok(Self::Timestamp),
       8 => result::Result::Ok(Self::Duration),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "LiteralKind",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "LiteralKind", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<LiteralKind> for u8 {
-  fn from(value: LiteralKind) -> u8 {
-    value as u8
-  }
+  fn from(value: LiteralKind) -> u8 { value as u8 }
 }
 
 impl LiteralKind {
@@ -387,9 +354,7 @@ impl bebop::BebopEncode for LiteralKind {
     // @@bebop_insertion_point(encode_end:LiteralKind)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for LiteralKind {
@@ -424,68 +389,24 @@ impl DecoratorTarget {
 impl bebop::BebopFlags for DecoratorTarget {
   type Bits = u8;
   const ALL_BITS: Self::Bits = 255;
-  fn bits(self) -> Self::Bits {
-    self.0
-  }
-  fn from_bits_retain(bits: Self::Bits) -> Self {
-    Self(bits)
-  }
+  fn bits(self) -> Self::Bits { self.0 }
+  fn from_bits_retain(bits: Self::Bits) -> Self { Self(bits) }
 }
 
-impl ops::BitOr for DecoratorTarget {
-  type Output = Self;
-  fn bitor(self, rhs: Self) -> Self {
-    Self(self.0 | rhs.0)
-  }
-}
-impl ops::BitOrAssign for DecoratorTarget {
-  fn bitor_assign(&mut self, rhs: Self) {
-    self.0 |= rhs.0;
-  }
-}
-impl ops::BitAnd for DecoratorTarget {
-  type Output = Self;
-  fn bitand(self, rhs: Self) -> Self {
-    Self(self.0 & rhs.0)
-  }
-}
-impl ops::BitAndAssign for DecoratorTarget {
-  fn bitand_assign(&mut self, rhs: Self) {
-    self.0 &= rhs.0;
-  }
-}
-impl ops::BitXor for DecoratorTarget {
-  type Output = Self;
-  fn bitxor(self, rhs: Self) -> Self {
-    Self(self.0 ^ rhs.0)
-  }
-}
-impl ops::BitXorAssign for DecoratorTarget {
-  fn bitxor_assign(&mut self, rhs: Self) {
-    self.0 ^= rhs.0;
-  }
-}
-impl ops::Not for DecoratorTarget {
-  type Output = Self;
-  fn not(self) -> Self {
-    Self(!self.0)
-  }
-}
-impl ops::Sub for DecoratorTarget {
-  type Output = Self;
-  fn sub(self, rhs: Self) -> Self {
-    Self(self.0 & !rhs.0)
-  }
-}
+impl ops::BitOr for DecoratorTarget { type Output = Self; fn bitor(self, rhs: Self) -> Self { Self(self.0 | rhs.0) } }
+impl ops::BitOrAssign for DecoratorTarget { fn bitor_assign(&mut self, rhs: Self) { self.0 |= rhs.0; } }
+impl ops::BitAnd for DecoratorTarget { type Output = Self; fn bitand(self, rhs: Self) -> Self { Self(self.0 & rhs.0) } }
+impl ops::BitAndAssign for DecoratorTarget { fn bitand_assign(&mut self, rhs: Self) { self.0 &= rhs.0; } }
+impl ops::BitXor for DecoratorTarget { type Output = Self; fn bitxor(self, rhs: Self) -> Self { Self(self.0 ^ rhs.0) } }
+impl ops::BitXorAssign for DecoratorTarget { fn bitxor_assign(&mut self, rhs: Self) { self.0 ^= rhs.0; } }
+impl ops::Not for DecoratorTarget { type Output = Self; fn not(self) -> Self { Self(!self.0) } }
+impl ops::Sub for DecoratorTarget { type Output = Self; fn sub(self, rhs: Self) -> Self { Self(self.0 & !rhs.0) } }
 
 impl<'buf> bebop::BebopDecode<'buf> for DecoratorTarget {
   #[inline(always)]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     let bits = reader.read_byte()?;
-    <Self as bebop::BebopFlags>::from_bits(bits).ok_or(bebop::DecodeError::InvalidFlags {
-      type_name: "DecoratorTarget",
-      bits: bits as u64,
-    })
+    <Self as bebop::BebopFlags>::from_bits(bits).ok_or(bebop::DecodeError::InvalidFlags { type_name: "DecoratorTarget", bits: bits as u64 })
   }
 }
 
@@ -507,18 +428,13 @@ impl convert::TryFrom<i32> for Edition {
       0 => result::Result::Ok(Self::Unknown),
       1000 => result::Result::Ok(Self::Edition2026),
       2147483647 => result::Result::Ok(Self::Max),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "Edition",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "Edition", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<Edition> for i32 {
-  fn from(value: Edition) -> i32 {
-    value as i32
-  }
+  fn from(value: Edition) -> i32 { value as i32 }
 }
 
 impl Edition {
@@ -533,9 +449,7 @@ impl bebop::BebopEncode for Edition {
     // @@bebop_insertion_point(encode_end:Edition)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for Edition {
@@ -567,19 +481,19 @@ impl<'buf> bebop::BebopDecode<'buf> for Edition {
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct TypeDescriptor<'buf> {
-  /// Discriminates which fields below are populated.
+/// Discriminates which fields below are populated.
   pub kind: option::Option<TypeKind>,
-  /// Element type when `kind == ARRAY`.
+/// Element type when `kind == ARRAY`.
   pub array_element: option::Option<boxed::Box<TypeDescriptor<'buf>>>,
-  /// Element type when `kind == FIXED_ARRAY`.
+/// Element type when `kind == FIXED_ARRAY`.
   pub fixed_array_element: option::Option<boxed::Box<TypeDescriptor<'buf>>>,
-  /// Element count when `kind == FIXED_ARRAY`. Range 1-65535.
+/// Element count when `kind == FIXED_ARRAY`. Range 1-65535.
   pub fixed_array_size: option::Option<u32>,
-  /// Key type when `kind == MAP`. Must be hashable (bool, integers, string, uuid).
+/// Key type when `kind == MAP`. Must be hashable (bool, integers, string, uuid).
   pub map_key: option::Option<boxed::Box<TypeDescriptor<'buf>>>,
-  /// Value type when `kind == MAP`.
+/// Value type when `kind == MAP`.
   pub map_value: option::Option<boxed::Box<TypeDescriptor<'buf>>>,
-  /// FQN when `kind == DEFINED`. Always fully qualified after linking.
+/// FQN when `kind == DEFINED`. Always fully qualified after linking.
   pub defined_fqn: option::Option<borrow::Cow<'buf, str>>,
 }
 
@@ -590,9 +504,7 @@ impl<'buf> TypeDescriptor<'buf> {
     TypeDescriptor {
       kind: self.kind,
       array_element: self.array_element.map(|v| boxed::Box::new(v.into_owned())),
-      fixed_array_element: self
-        .fixed_array_element
-        .map(|v| boxed::Box::new(v.into_owned())),
+      fixed_array_element: self.fixed_array_element.map(|v| boxed::Box::new(v.into_owned())),
       fixed_array_size: self.fixed_array_size,
       map_key: self.map_key.map(|v| boxed::Box::new(v.into_owned())),
       map_value: self.map_value.map(|v| boxed::Box::new(v.into_owned())),
@@ -680,54 +592,16 @@ impl<'buf> bebop::BebopDecode<'buf> for TypeDescriptor<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.kind =
-            option::Option::Some(TypeKind::decode(reader).for_field("TypeDescriptor", "kind")?)
-        }
-        2 => {
-          msg.array_element = option::Option::Some(boxed::Box::new(
-            TypeDescriptor::decode(reader).for_field("TypeDescriptor", "array_element")?,
-          ))
-        }
-        3 => {
-          msg.fixed_array_element = option::Option::Some(boxed::Box::new(
-            TypeDescriptor::decode(reader).for_field("TypeDescriptor", "fixed_array_element")?,
-          ))
-        }
-        4 => {
-          msg.fixed_array_size = option::Option::Some(
-            reader
-              .read_u32()
-              .for_field("TypeDescriptor", "fixed_array_size")?,
-          )
-        }
-        5 => {
-          msg.map_key = option::Option::Some(boxed::Box::new(
-            TypeDescriptor::decode(reader).for_field("TypeDescriptor", "map_key")?,
-          ))
-        }
-        6 => {
-          msg.map_value = option::Option::Some(boxed::Box::new(
-            TypeDescriptor::decode(reader).for_field("TypeDescriptor", "map_value")?,
-          ))
-        }
-        7 => {
-          msg.defined_fqn = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("TypeDescriptor", "defined_fqn")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "TypeDescriptor",
-            tag,
-          });
-        }
+        1 => msg.kind = option::Option::Some(TypeKind::decode(reader).for_field("TypeDescriptor", "kind")?),
+        2 => msg.array_element = option::Option::Some(boxed::Box::new(TypeDescriptor::decode(reader).for_field("TypeDescriptor", "array_element")?)),
+        3 => msg.fixed_array_element = option::Option::Some(boxed::Box::new(TypeDescriptor::decode(reader).for_field("TypeDescriptor", "fixed_array_element")?)),
+        4 => msg.fixed_array_size = option::Option::Some(reader.read_u32().for_field("TypeDescriptor", "fixed_array_size")?),
+        5 => msg.map_key = option::Option::Some(boxed::Box::new(TypeDescriptor::decode(reader).for_field("TypeDescriptor", "map_key")?)),
+        6 => msg.map_value = option::Option::Some(boxed::Box::new(TypeDescriptor::decode(reader).for_field("TypeDescriptor", "map_value")?)),
+        7 => msg.defined_fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("TypeDescriptor", "defined_fqn")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "TypeDescriptor", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:TypeDescriptor)
@@ -780,14 +654,14 @@ pub struct LiteralValue<'buf> {
   pub float_value: option::Option<f64>,
   pub string_value: option::Option<borrow::Cow<'buf, str>>,
   pub uuid_value: option::Option<bebop::Uuid>,
-  /// Original source text before `$(...)` expansion. Only set for string
-  /// literals that contained environment variable references.
+/// Original source text before `$(...)` expansion. Only set for string
+/// literals that contained environment variable references.
   pub raw_value: option::Option<borrow::Cow<'buf, str>>,
-  /// When `kind == BYTES`.
+/// When `kind == BYTES`.
   pub bytes_value: option::Option<bebop::BebopBytes<'buf>>,
-  /// When `kind == TIMESTAMP`.
+/// When `kind == TIMESTAMP`.
   pub timestamp_value: option::Option<bebop::BebopTimestamp>,
-  /// When `kind == DURATION`.
+/// When `kind == DURATION`.
   pub duration_value: option::Option<bebop::BebopDuration>,
 }
 
@@ -800,9 +674,7 @@ impl<'buf> LiteralValue<'buf> {
       bool_value: self.bool_value,
       int_value: self.int_value,
       float_value: self.float_value,
-      string_value: self
-        .string_value
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      string_value: self.string_value.map(|v| borrow::Cow::Owned(v.into_owned())),
       uuid_value: self.uuid_value,
       raw_value: self.raw_value.map(|v| borrow::Cow::Owned(v.into_owned())),
       bytes_value: self.bytes_value.map(|v| v.into_owned()),
@@ -912,69 +784,19 @@ impl<'buf> bebop::BebopDecode<'buf> for LiteralValue<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.kind =
-            option::Option::Some(LiteralKind::decode(reader).for_field("LiteralValue", "kind")?)
-        }
-        2 => {
-          msg.bool_value =
-            option::Option::Some(reader.read_bool().for_field("LiteralValue", "bool_value")?)
-        }
-        3 => {
-          msg.int_value =
-            option::Option::Some(reader.read_i64().for_field("LiteralValue", "int_value")?)
-        }
-        4 => {
-          msg.float_value =
-            option::Option::Some(reader.read_f64().for_field("LiteralValue", "float_value")?)
-        }
-        5 => {
-          msg.string_value = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("LiteralValue", "string_value")?,
-          ))
-        }
-        6 => {
-          msg.uuid_value =
-            option::Option::Some(reader.read_uuid().for_field("LiteralValue", "uuid_value")?)
-        }
-        7 => {
-          msg.raw_value = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("LiteralValue", "raw_value")?,
-          ))
-        }
-        8 => {
-          msg.bytes_value = option::Option::Some(bebop::BebopBytes::borrowed(
-            reader
-              .read_byte_slice()
-              .for_field("LiteralValue", "bytes_value")?,
-          ))
-        }
-        9 => {
-          msg.timestamp_value = option::Option::Some(
-            reader
-              .read_timestamp()
-              .for_field("LiteralValue", "timestamp_value")?,
-          )
-        }
-        10 => {
-          msg.duration_value = option::Option::Some(
-            reader
-              .read_duration()
-              .for_field("LiteralValue", "duration_value")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "LiteralValue",
-            tag,
-          });
-        }
+        1 => msg.kind = option::Option::Some(LiteralKind::decode(reader).for_field("LiteralValue", "kind")?),
+        2 => msg.bool_value = option::Option::Some(reader.read_bool().for_field("LiteralValue", "bool_value")?),
+        3 => msg.int_value = option::Option::Some(reader.read_i64().for_field("LiteralValue", "int_value")?),
+        4 => msg.float_value = option::Option::Some(reader.read_f64().for_field("LiteralValue", "float_value")?),
+        5 => msg.string_value = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("LiteralValue", "string_value")?)),
+        6 => msg.uuid_value = option::Option::Some(reader.read_uuid().for_field("LiteralValue", "uuid_value")?),
+        7 => msg.raw_value = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("LiteralValue", "raw_value")?)),
+        8 => msg.bytes_value = option::Option::Some(bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field("LiteralValue", "bytes_value")?)),
+        9 => msg.timestamp_value = option::Option::Some(reader.read_timestamp().for_field("LiteralValue", "timestamp_value")?),
+        10 => msg.duration_value = option::Option::Some(reader.read_duration().for_field("LiteralValue", "duration_value")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "LiteralValue", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:LiteralValue)
@@ -1094,11 +916,11 @@ impl<'buf> DecoratorArg<'buf> {
 /// metadata without re-running Lua.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct DecoratorUsage<'buf> {
-  /// FQN of the decorator definition (e.g., `validators.range`).
+/// FQN of the decorator definition (e.g., `validators.range`).
   pub fqn: option::Option<borrow::Cow<'buf, str>>,
-  /// Arguments passed at the usage site, in declaration order.
+/// Arguments passed at the usage site, in declaration order.
   pub args: option::Option<vec::Vec<DecoratorArg<'buf>>>,
-  /// Results from the decorator's export block.
+/// Results from the decorator's export block.
   pub export_data: option::Option<bebop::HashMap<borrow::Cow<'buf, str>, LiteralValue<'buf>>>,
 }
 
@@ -1108,14 +930,8 @@ impl<'buf> DecoratorUsage<'buf> {
   pub fn into_owned(self) -> DecoratorUsageOwned {
     DecoratorUsage {
       fqn: self.fqn.map(|v| borrow::Cow::Owned(v.into_owned())),
-      args: self
-        .args
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
-      export_data: self.export_data.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned()))
-          .collect()
-      }),
+      args: self.args.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      export_data: self.export_data.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), _v.into_owned())).collect()),
     }
   }
 }
@@ -1139,10 +955,7 @@ impl<'buf> bebop::BebopEncode for DecoratorUsage<'buf> {
     }
     if let option::Option::Some(ref v) = self.export_data {
       writer.write_tag(3);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _v.encode(_w);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _v.encode(_w); });
     }
     writer.write_end_marker();
     writer.fill_message_length(pos);
@@ -1155,13 +968,10 @@ impl<'buf> bebop::BebopEncode for DecoratorUsage<'buf> {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
     }
     if let option::Option::Some(ref v) = self.args {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.export_data {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len()) + _v.encoded_size()
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + _v.encoded_size()));
     }
     size
   }
@@ -1177,40 +987,12 @@ impl<'buf> bebop::BebopDecode<'buf> for DecoratorUsage<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.fqn = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("DecoratorUsage", "fqn")?,
-          ))
-        }
-        2 => {
-          msg.args = option::Option::Some(
-            reader
-              .read_array(|_r| DecoratorArg::decode(_r))
-              .for_field("DecoratorUsage", "args")?,
-          )
-        }
-        3 => {
-          msg.export_data = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  LiteralValue::decode(_r)?,
-                ))
-              })
-              .for_field("DecoratorUsage", "export_data")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "DecoratorUsage",
-            tag,
-          });
-        }
+        1 => msg.fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DecoratorUsage", "fqn")?)),
+        2 => msg.args = option::Option::Some(reader.read_array(|_r| DecoratorArg::decode(_r)).for_field("DecoratorUsage", "args")?),
+        3 => msg.export_data = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, LiteralValue::decode(_r)?))).for_field("DecoratorUsage", "export_data")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "DecoratorUsage", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:DecoratorUsage)
@@ -1227,17 +1009,8 @@ impl<'buf> DecoratorUsage<'buf> {
     self.args = option::Option::Some(value.into_iter().collect());
     self
   }
-  pub fn with_export_data(
-    mut self,
-    value: impl iter::IntoIterator<
-      Item = (
-        impl convert::Into<borrow::Cow<'buf, str>>,
-        LiteralValue<'buf>,
-      ),
-    >,
-  ) -> Self {
-    self.export_data =
-      option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v)).collect());
+  pub fn with_export_data(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, LiteralValue<'buf>)>) -> Self {
+    self.export_data = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v)).collect());
     self
   }
   // @@bebop_insertion_point(message_scope:DecoratorUsage)
@@ -1252,10 +1025,10 @@ impl<'buf> DecoratorUsage<'buf> {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct FieldDescriptor<'buf> {
   pub name: option::Option<borrow::Cow<'buf, str>>,
-  /// Text from preceding `///` comments in source.
+/// Text from preceding `///` comments in source.
   pub documentation: option::Option<borrow::Cow<'buf, str>>,
   pub r#type: option::Option<TypeDescriptor<'buf>>,
-  /// Wire tag: 0 for struct fields, 1-255 for message fields.
+/// Wire tag: 0 for struct fields, 1-255 for message fields.
   pub index: option::Option<u32>,
   pub decorators: option::Option<vec::Vec<DecoratorUsage<'buf>>>,
 }
@@ -1266,14 +1039,10 @@ impl<'buf> FieldDescriptor<'buf> {
   pub fn into_owned(self) -> FieldDescriptorOwned {
     FieldDescriptor {
       name: self.name.map(|v| borrow::Cow::Owned(v.into_owned())),
-      documentation: self
-        .documentation
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      documentation: self.documentation.map(|v| borrow::Cow::Owned(v.into_owned())),
       r#type: self.r#type.map(|v| v.into_owned()),
       index: self.index,
-      decorators: self
-        .decorators
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      decorators: self.decorators.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -1327,8 +1096,7 @@ impl<'buf> bebop::BebopEncode for FieldDescriptor<'buf> {
       size += bebop::wire_size::tagged_size(mem::size_of::<u32>());
     }
     if let option::Option::Some(ref v) = self.decorators {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -1344,43 +1112,14 @@ impl<'buf> bebop::BebopDecode<'buf> for FieldDescriptor<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("FieldDescriptor", "name")?,
-          ))
-        }
-        2 => {
-          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("FieldDescriptor", "documentation")?,
-          ))
-        }
-        3 => {
-          msg.r#type = option::Option::Some(
-            TypeDescriptor::decode(reader).for_field("FieldDescriptor", "type")?,
-          )
-        }
-        4 => {
-          msg.index = option::Option::Some(reader.read_u32().for_field("FieldDescriptor", "index")?)
-        }
-        5 => {
-          msg.decorators = option::Option::Some(
-            reader
-              .read_array(|_r| DecoratorUsage::decode(_r))
-              .for_field("FieldDescriptor", "decorators")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "FieldDescriptor",
-            tag,
-          });
-        }
+        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("FieldDescriptor", "name")?)),
+        2 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("FieldDescriptor", "documentation")?)),
+        3 => msg.r#type = option::Option::Some(TypeDescriptor::decode(reader).for_field("FieldDescriptor", "type")?),
+        4 => msg.index = option::Option::Some(reader.read_u32().for_field("FieldDescriptor", "index")?),
+        5 => msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r)).for_field("FieldDescriptor", "decorators")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "FieldDescriptor", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:FieldDescriptor)
@@ -1405,10 +1144,7 @@ impl<'buf> FieldDescriptor<'buf> {
     self.index = option::Option::Some(value);
     self
   }
-  pub fn with_decorators(
-    mut self,
-    value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>,
-  ) -> Self {
+  pub fn with_decorators(mut self, value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>) -> Self {
     self.decorators = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -1423,10 +1159,10 @@ impl<'buf> FieldDescriptor<'buf> {
 pub struct EnumMemberDescriptor<'buf> {
   pub name: option::Option<borrow::Cow<'buf, str>>,
   pub documentation: option::Option<borrow::Cow<'buf, str>>,
-  /// Stored unsigned. Reinterpret per the parent enum's `base_type`.
+/// Stored unsigned. Reinterpret per the parent enum's `base_type`.
   pub value: option::Option<u64>,
   pub decorators: option::Option<vec::Vec<DecoratorUsage<'buf>>>,
-  /// Original expression text (e.g., `1 << 3`). Absent for simple literals.
+/// Original expression text (e.g., `1 << 3`). Absent for simple literals.
   pub value_expr: option::Option<borrow::Cow<'buf, str>>,
 }
 
@@ -1436,13 +1172,9 @@ impl<'buf> EnumMemberDescriptor<'buf> {
   pub fn into_owned(self) -> EnumMemberDescriptorOwned {
     EnumMemberDescriptor {
       name: self.name.map(|v| borrow::Cow::Owned(v.into_owned())),
-      documentation: self
-        .documentation
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      documentation: self.documentation.map(|v| borrow::Cow::Owned(v.into_owned())),
       value: self.value,
-      decorators: self
-        .decorators
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      decorators: self.decorators.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
       value_expr: self.value_expr.map(|v| borrow::Cow::Owned(v.into_owned())),
     }
   }
@@ -1494,8 +1226,7 @@ impl<'buf> bebop::BebopEncode for EnumMemberDescriptor<'buf> {
       size += bebop::wire_size::tagged_size(mem::size_of::<u64>());
     }
     if let option::Option::Some(ref v) = self.decorators {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.value_expr {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
@@ -1514,51 +1245,14 @@ impl<'buf> bebop::BebopDecode<'buf> for EnumMemberDescriptor<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("EnumMemberDescriptor", "name")?,
-          ))
-        }
-        2 => {
-          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("EnumMemberDescriptor", "documentation")?,
-          ))
-        }
-        3 => {
-          msg.value = option::Option::Some(
-            reader
-              .read_u64()
-              .for_field("EnumMemberDescriptor", "value")?,
-          )
-        }
-        4 => {
-          msg.decorators = option::Option::Some(
-            reader
-              .read_array(|_r| DecoratorUsage::decode(_r))
-              .for_field("EnumMemberDescriptor", "decorators")?,
-          )
-        }
-        5 => {
-          msg.value_expr = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("EnumMemberDescriptor", "value_expr")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "EnumMemberDescriptor",
-            tag,
-          });
-        }
+        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("EnumMemberDescriptor", "name")?)),
+        2 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("EnumMemberDescriptor", "documentation")?)),
+        3 => msg.value = option::Option::Some(reader.read_u64().for_field("EnumMemberDescriptor", "value")?),
+        4 => msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r)).for_field("EnumMemberDescriptor", "decorators")?),
+        5 => msg.value_expr = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("EnumMemberDescriptor", "value_expr")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "EnumMemberDescriptor", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:EnumMemberDescriptor)
@@ -1579,10 +1273,7 @@ impl<'buf> EnumMemberDescriptor<'buf> {
     self.value = option::Option::Some(value);
     self
   }
-  pub fn with_decorators(
-    mut self,
-    value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>,
-  ) -> Self {
+  pub fn with_decorators(mut self, value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>) -> Self {
     self.decorators = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -1609,14 +1300,14 @@ impl<'buf> EnumMemberDescriptor<'buf> {
 /// Sets `type_ref_fqn = "mypackage.Rect"` and `name = "rect"`.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct UnionBranchDescriptor<'buf> {
-  /// Wire discriminator byte. Range 1-255.
+/// Wire discriminator byte. Range 1-255.
   pub discriminator: option::Option<u8>,
   pub documentation: option::Option<borrow::Cow<'buf, str>>,
-  /// FQN of inline definition. Mutually exclusive with `type_ref_fqn`.
+/// FQN of inline definition. Mutually exclusive with `type_ref_fqn`.
   pub inline_fqn: option::Option<borrow::Cow<'buf, str>>,
-  /// FQN of referenced type. Mutually exclusive with `inline_fqn`.
+/// FQN of referenced type. Mutually exclusive with `inline_fqn`.
   pub type_ref_fqn: option::Option<borrow::Cow<'buf, str>>,
-  /// Branch name for type-reference branches.
+/// Branch name for type-reference branches.
   pub name: option::Option<borrow::Cow<'buf, str>>,
   pub decorators: option::Option<vec::Vec<DecoratorUsage<'buf>>>,
 }
@@ -1627,17 +1318,11 @@ impl<'buf> UnionBranchDescriptor<'buf> {
   pub fn into_owned(self) -> UnionBranchDescriptorOwned {
     UnionBranchDescriptor {
       discriminator: self.discriminator,
-      documentation: self
-        .documentation
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      documentation: self.documentation.map(|v| borrow::Cow::Owned(v.into_owned())),
       inline_fqn: self.inline_fqn.map(|v| borrow::Cow::Owned(v.into_owned())),
-      type_ref_fqn: self
-        .type_ref_fqn
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      type_ref_fqn: self.type_ref_fqn.map(|v| borrow::Cow::Owned(v.into_owned())),
       name: self.name.map(|v| borrow::Cow::Owned(v.into_owned())),
-      decorators: self
-        .decorators
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      decorators: self.decorators.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -1698,8 +1383,7 @@ impl<'buf> bebop::BebopEncode for UnionBranchDescriptor<'buf> {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
     }
     if let option::Option::Some(ref v) = self.decorators {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -1715,58 +1399,15 @@ impl<'buf> bebop::BebopDecode<'buf> for UnionBranchDescriptor<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.discriminator = option::Option::Some(
-            reader
-              .read_byte()
-              .for_field("UnionBranchDescriptor", "discriminator")?,
-          )
-        }
-        2 => {
-          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("UnionBranchDescriptor", "documentation")?,
-          ))
-        }
-        3 => {
-          msg.inline_fqn = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("UnionBranchDescriptor", "inline_fqn")?,
-          ))
-        }
-        4 => {
-          msg.type_ref_fqn = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("UnionBranchDescriptor", "type_ref_fqn")?,
-          ))
-        }
-        5 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("UnionBranchDescriptor", "name")?,
-          ))
-        }
-        6 => {
-          msg.decorators = option::Option::Some(
-            reader
-              .read_array(|_r| DecoratorUsage::decode(_r))
-              .for_field("UnionBranchDescriptor", "decorators")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "UnionBranchDescriptor",
-            tag,
-          });
-        }
+        1 => msg.discriminator = option::Option::Some(reader.read_byte().for_field("UnionBranchDescriptor", "discriminator")?),
+        2 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("UnionBranchDescriptor", "documentation")?)),
+        3 => msg.inline_fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("UnionBranchDescriptor", "inline_fqn")?)),
+        4 => msg.type_ref_fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("UnionBranchDescriptor", "type_ref_fqn")?)),
+        5 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("UnionBranchDescriptor", "name")?)),
+        6 => msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r)).for_field("UnionBranchDescriptor", "decorators")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "UnionBranchDescriptor", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:UnionBranchDescriptor)
@@ -1795,10 +1436,7 @@ impl<'buf> UnionBranchDescriptor<'buf> {
     self.name = option::Option::Some(value.into());
     self
   }
-  pub fn with_decorators(
-    mut self,
-    value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>,
-  ) -> Self {
+  pub fn with_decorators(mut self, value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>) -> Self {
     self.decorators = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -1815,7 +1453,7 @@ pub struct MethodDescriptor<'buf> {
   pub request_type: option::Option<TypeDescriptor<'buf>>,
   pub response_type: option::Option<TypeDescriptor<'buf>>,
   pub method_type: option::Option<MethodType>,
-  /// MurmurHash3 of `/ServiceName/MethodName`.
+/// MurmurHash3 of `/ServiceName/MethodName`.
   pub id: option::Option<u32>,
   pub decorators: option::Option<vec::Vec<DecoratorUsage<'buf>>>,
 }
@@ -1826,16 +1464,12 @@ impl<'buf> MethodDescriptor<'buf> {
   pub fn into_owned(self) -> MethodDescriptorOwned {
     MethodDescriptor {
       name: self.name.map(|v| borrow::Cow::Owned(v.into_owned())),
-      documentation: self
-        .documentation
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      documentation: self.documentation.map(|v| borrow::Cow::Owned(v.into_owned())),
       request_type: self.request_type.map(|v| v.into_owned()),
       response_type: self.response_type.map(|v| v.into_owned()),
       method_type: self.method_type,
       id: self.id,
-      decorators: self
-        .decorators
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      decorators: self.decorators.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -1903,8 +1537,7 @@ impl<'buf> bebop::BebopEncode for MethodDescriptor<'buf> {
       size += bebop::wire_size::tagged_size(mem::size_of::<u32>());
     }
     if let option::Option::Some(ref v) = self.decorators {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -1920,51 +1553,16 @@ impl<'buf> bebop::BebopDecode<'buf> for MethodDescriptor<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("MethodDescriptor", "name")?,
-          ))
-        }
-        2 => {
-          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("MethodDescriptor", "documentation")?,
-          ))
-        }
-        3 => {
-          msg.request_type = option::Option::Some(
-            TypeDescriptor::decode(reader).for_field("MethodDescriptor", "request_type")?,
-          )
-        }
-        4 => {
-          msg.response_type = option::Option::Some(
-            TypeDescriptor::decode(reader).for_field("MethodDescriptor", "response_type")?,
-          )
-        }
-        5 => {
-          msg.method_type = option::Option::Some(
-            MethodType::decode(reader).for_field("MethodDescriptor", "method_type")?,
-          )
-        }
+        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("MethodDescriptor", "name")?)),
+        2 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("MethodDescriptor", "documentation")?)),
+        3 => msg.request_type = option::Option::Some(TypeDescriptor::decode(reader).for_field("MethodDescriptor", "request_type")?),
+        4 => msg.response_type = option::Option::Some(TypeDescriptor::decode(reader).for_field("MethodDescriptor", "response_type")?),
+        5 => msg.method_type = option::Option::Some(MethodType::decode(reader).for_field("MethodDescriptor", "method_type")?),
         6 => msg.id = option::Option::Some(reader.read_u32().for_field("MethodDescriptor", "id")?),
-        7 => {
-          msg.decorators = option::Option::Some(
-            reader
-              .read_array(|_r| DecoratorUsage::decode(_r))
-              .for_field("MethodDescriptor", "decorators")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "MethodDescriptor",
-            tag,
-          });
-        }
+        7 => msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r)).for_field("MethodDescriptor", "decorators")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "MethodDescriptor", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:MethodDescriptor)
@@ -1997,10 +1595,7 @@ impl<'buf> MethodDescriptor<'buf> {
     self.id = option::Option::Some(value);
     self
   }
-  pub fn with_decorators(
-    mut self,
-    value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>,
-  ) -> Self {
+  pub fn with_decorators(mut self, value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>) -> Self {
     self.decorators = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -2016,7 +1611,7 @@ impl<'buf> MethodDescriptor<'buf> {
 pub struct EnumDef<'buf> {
   pub base_type: option::Option<TypeKind>,
   pub members: option::Option<vec::Vec<EnumMemberDescriptor<'buf>>>,
-  /// True when `@flags` is applied. Members are bit positions for OR.
+/// True when `@flags` is applied. Members are bit positions for OR.
   pub is_flags: option::Option<bool>,
 }
 
@@ -2026,9 +1621,7 @@ impl<'buf> EnumDef<'buf> {
   pub fn into_owned(self) -> EnumDefOwned {
     EnumDef {
       base_type: self.base_type,
-      members: self
-        .members
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      members: self.members.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
       is_flags: self.is_flags,
     }
   }
@@ -2066,8 +1659,7 @@ impl<'buf> bebop::BebopEncode for EnumDef<'buf> {
       size += bebop::wire_size::tagged_size(v.encoded_size());
     }
     if let option::Option::Some(ref v) = self.members {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(v) = self.is_flags {
       size += bebop::wire_size::tagged_size(mem::size_of::<bool>());
@@ -2086,30 +1678,12 @@ impl<'buf> bebop::BebopDecode<'buf> for EnumDef<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.base_type =
-            option::Option::Some(TypeKind::decode(reader).for_field("EnumDef", "base_type")?)
-        }
-        2 => {
-          msg.members = option::Option::Some(
-            reader
-              .read_array(|_r| EnumMemberDescriptor::decode(_r))
-              .for_field("EnumDef", "members")?,
-          )
-        }
-        3 => {
-          msg.is_flags = option::Option::Some(reader.read_bool().for_field("EnumDef", "is_flags")?)
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "EnumDef",
-            tag,
-          });
-        }
+        1 => msg.base_type = option::Option::Some(TypeKind::decode(reader).for_field("EnumDef", "base_type")?),
+        2 => msg.members = option::Option::Some(reader.read_array(|_r| EnumMemberDescriptor::decode(_r)).for_field("EnumDef", "members")?),
+        3 => msg.is_flags = option::Option::Some(reader.read_bool().for_field("EnumDef", "is_flags")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "EnumDef", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:EnumDef)
@@ -2122,10 +1696,7 @@ impl<'buf> EnumDef<'buf> {
     self.base_type = option::Option::Some(value);
     self
   }
-  pub fn with_members(
-    mut self,
-    value: impl iter::IntoIterator<Item = EnumMemberDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_members(mut self, value: impl iter::IntoIterator<Item = EnumMemberDescriptor<'buf>>) -> Self {
     self.members = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -2143,10 +1714,10 @@ impl<'buf> EnumDef<'buf> {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct StructDef<'buf> {
   pub fields: option::Option<vec::Vec<FieldDescriptor<'buf>>>,
-  /// True when declared with `mut`. Mutable structs allow field reassignment.
+/// True when declared with `mut`. Mutable structs allow field reassignment.
   pub is_mutable: option::Option<bool>,
-  /// Total wire bytes when all fields are fixed-size. Zero when any field
-  /// is variable-size. Generators use this to pre-allocate buffers.
+/// Total wire bytes when all fields are fixed-size. Zero when any field
+/// is variable-size. Generators use this to pre-allocate buffers.
   pub fixed_size: option::Option<u32>,
 }
 
@@ -2155,9 +1726,7 @@ pub type StructDefOwned = StructDef<'static>;
 impl<'buf> StructDef<'buf> {
   pub fn into_owned(self) -> StructDefOwned {
     StructDef {
-      fields: self
-        .fields
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      fields: self.fields.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
       is_mutable: self.is_mutable,
       fixed_size: self.fixed_size,
     }
@@ -2193,8 +1762,7 @@ impl<'buf> bebop::BebopEncode for StructDef<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.fields {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(v) = self.is_mutable {
       size += bebop::wire_size::tagged_size(mem::size_of::<bool>());
@@ -2216,31 +1784,12 @@ impl<'buf> bebop::BebopDecode<'buf> for StructDef<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.fields = option::Option::Some(
-            reader
-              .read_array(|_r| FieldDescriptor::decode(_r))
-              .for_field("StructDef", "fields")?,
-          )
-        }
-        2 => {
-          msg.is_mutable =
-            option::Option::Some(reader.read_bool().for_field("StructDef", "is_mutable")?)
-        }
-        3 => {
-          msg.fixed_size =
-            option::Option::Some(reader.read_u32().for_field("StructDef", "fixed_size")?)
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "StructDef",
-            tag,
-          });
-        }
+        1 => msg.fields = option::Option::Some(reader.read_array(|_r| FieldDescriptor::decode(_r)).for_field("StructDef", "fields")?),
+        2 => msg.is_mutable = option::Option::Some(reader.read_bool().for_field("StructDef", "is_mutable")?),
+        3 => msg.fixed_size = option::Option::Some(reader.read_u32().for_field("StructDef", "fixed_size")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "StructDef", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:StructDef)
@@ -2249,10 +1798,7 @@ impl<'buf> bebop::BebopDecode<'buf> for StructDef<'buf> {
 }
 
 impl<'buf> StructDef<'buf> {
-  pub fn with_fields(
-    mut self,
-    value: impl iter::IntoIterator<Item = FieldDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_fields(mut self, value: impl iter::IntoIterator<Item = FieldDescriptor<'buf>>) -> Self {
     self.fields = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -2280,9 +1826,7 @@ pub type MessageDefOwned = MessageDef<'static>;
 impl<'buf> MessageDef<'buf> {
   pub fn into_owned(self) -> MessageDefOwned {
     MessageDef {
-      fields: self
-        .fields
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      fields: self.fields.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -2308,8 +1852,7 @@ impl<'buf> bebop::BebopEncode for MessageDef<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.fields {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -2325,23 +1868,10 @@ impl<'buf> bebop::BebopDecode<'buf> for MessageDef<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.fields = option::Option::Some(
-            reader
-              .read_array(|_r| FieldDescriptor::decode(_r))
-              .for_field("MessageDef", "fields")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "MessageDef",
-            tag,
-          });
-        }
+        1 => msg.fields = option::Option::Some(reader.read_array(|_r| FieldDescriptor::decode(_r)).for_field("MessageDef", "fields")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "MessageDef", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:MessageDef)
@@ -2350,10 +1880,7 @@ impl<'buf> bebop::BebopDecode<'buf> for MessageDef<'buf> {
 }
 
 impl<'buf> MessageDef<'buf> {
-  pub fn with_fields(
-    mut self,
-    value: impl iter::IntoIterator<Item = FieldDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_fields(mut self, value: impl iter::IntoIterator<Item = FieldDescriptor<'buf>>) -> Self {
     self.fields = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -2373,9 +1900,7 @@ pub type UnionDefOwned = UnionDef<'static>;
 impl<'buf> UnionDef<'buf> {
   pub fn into_owned(self) -> UnionDefOwned {
     UnionDef {
-      branches: self
-        .branches
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      branches: self.branches.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -2401,8 +1926,7 @@ impl<'buf> bebop::BebopEncode for UnionDef<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.branches {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -2418,23 +1942,10 @@ impl<'buf> bebop::BebopDecode<'buf> for UnionDef<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.branches = option::Option::Some(
-            reader
-              .read_array(|_r| UnionBranchDescriptor::decode(_r))
-              .for_field("UnionDef", "branches")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "UnionDef",
-            tag,
-          });
-        }
+        1 => msg.branches = option::Option::Some(reader.read_array(|_r| UnionBranchDescriptor::decode(_r)).for_field("UnionDef", "branches")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "UnionDef", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:UnionDef)
@@ -2443,10 +1954,7 @@ impl<'buf> bebop::BebopDecode<'buf> for UnionDef<'buf> {
 }
 
 impl<'buf> UnionDef<'buf> {
-  pub fn with_branches(
-    mut self,
-    value: impl iter::IntoIterator<Item = UnionBranchDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_branches(mut self, value: impl iter::IntoIterator<Item = UnionBranchDescriptor<'buf>>) -> Self {
     self.branches = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -2464,9 +1972,7 @@ pub type ServiceDefOwned = ServiceDef<'static>;
 impl<'buf> ServiceDef<'buf> {
   pub fn into_owned(self) -> ServiceDefOwned {
     ServiceDef {
-      methods: self
-        .methods
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      methods: self.methods.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -2492,8 +1998,7 @@ impl<'buf> bebop::BebopEncode for ServiceDef<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.methods {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -2509,23 +2014,10 @@ impl<'buf> bebop::BebopDecode<'buf> for ServiceDef<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.methods = option::Option::Some(
-            reader
-              .read_array(|_r| MethodDescriptor::decode(_r))
-              .for_field("ServiceDef", "methods")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "ServiceDef",
-            tag,
-          });
-        }
+        1 => msg.methods = option::Option::Some(reader.read_array(|_r| MethodDescriptor::decode(_r)).for_field("ServiceDef", "methods")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "ServiceDef", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:ServiceDef)
@@ -2534,10 +2026,7 @@ impl<'buf> bebop::BebopDecode<'buf> for ServiceDef<'buf> {
 }
 
 impl<'buf> ServiceDef<'buf> {
-  pub fn with_methods(
-    mut self,
-    value: impl iter::IntoIterator<Item = MethodDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_methods(mut self, value: impl iter::IntoIterator<Item = MethodDescriptor<'buf>>) -> Self {
     self.methods = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -2613,24 +2102,11 @@ impl<'buf> bebop::BebopDecode<'buf> for ConstDef<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.r#type =
-            option::Option::Some(TypeDescriptor::decode(reader).for_field("ConstDef", "type")?)
-        }
-        2 => {
-          msg.value =
-            option::Option::Some(LiteralValue::decode(reader).for_field("ConstDef", "value")?)
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "ConstDef",
-            tag,
-          });
-        }
+        1 => msg.r#type = option::Option::Some(TypeDescriptor::decode(reader).for_field("ConstDef", "type")?),
+        2 => msg.value = option::Option::Some(LiteralValue::decode(reader).for_field("ConstDef", "value")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "ConstDef", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:ConstDef)
@@ -2662,16 +2138,16 @@ impl<'buf> ConstDef<'buf> {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct DecoratorParamDef<'buf> {
   pub name: option::Option<borrow::Cow<'buf, str>>,
-  /// Description from the `///` comment preceding this param.
+/// Description from the `///` comment preceding this param.
   pub description: option::Option<borrow::Cow<'buf, str>>,
-  /// Must be a scalar TypeKind.
+/// Must be a scalar TypeKind.
   pub r#type: option::Option<TypeKind>,
-  /// True for required (`!`) params, false for optional (`?`).
+/// True for required (`!`) params, false for optional (`?`).
   pub required: option::Option<bool>,
-  /// Default value for optional params. Absent for required params.
+/// Default value for optional params. Absent for required params.
   pub default_value: option::Option<LiteralValue<'buf>>,
-  /// Allowed-value constraint from `in [...]`. When non-empty, arguments
-  /// must match one of these values.
+/// Allowed-value constraint from `in [...]`. When non-empty, arguments
+/// must match one of these values.
   pub allowed_values: option::Option<vec::Vec<LiteralValue<'buf>>>,
 }
 
@@ -2685,9 +2161,7 @@ impl<'buf> DecoratorParamDef<'buf> {
       r#type: self.r#type,
       required: self.required,
       default_value: self.default_value.map(|v| v.into_owned()),
-      allowed_values: self
-        .allowed_values
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      allowed_values: self.allowed_values.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -2748,8 +2222,7 @@ impl<'buf> bebop::BebopEncode for DecoratorParamDef<'buf> {
       size += bebop::wire_size::tagged_size(v.encoded_size());
     }
     if let option::Option::Some(ref v) = self.allowed_values {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -2765,51 +2238,15 @@ impl<'buf> bebop::BebopDecode<'buf> for DecoratorParamDef<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("DecoratorParamDef", "name")?,
-          ))
-        }
-        2 => {
-          msg.description = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("DecoratorParamDef", "description")?,
-          ))
-        }
-        3 => {
-          msg.r#type =
-            option::Option::Some(TypeKind::decode(reader).for_field("DecoratorParamDef", "type")?)
-        }
-        4 => {
-          msg.required = option::Option::Some(
-            reader
-              .read_bool()
-              .for_field("DecoratorParamDef", "required")?,
-          )
-        }
-        5 => {
-          msg.default_value = option::Option::Some(
-            LiteralValue::decode(reader).for_field("DecoratorParamDef", "default_value")?,
-          )
-        }
-        6 => {
-          msg.allowed_values = option::Option::Some(
-            reader
-              .read_array(|_r| LiteralValue::decode(_r))
-              .for_field("DecoratorParamDef", "allowed_values")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "DecoratorParamDef",
-            tag,
-          });
-        }
+        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DecoratorParamDef", "name")?)),
+        2 => msg.description = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DecoratorParamDef", "description")?)),
+        3 => msg.r#type = option::Option::Some(TypeKind::decode(reader).for_field("DecoratorParamDef", "type")?),
+        4 => msg.required = option::Option::Some(reader.read_bool().for_field("DecoratorParamDef", "required")?),
+        5 => msg.default_value = option::Option::Some(LiteralValue::decode(reader).for_field("DecoratorParamDef", "default_value")?),
+        6 => msg.allowed_values = option::Option::Some(reader.read_array(|_r| LiteralValue::decode(_r)).for_field("DecoratorParamDef", "allowed_values")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "DecoratorParamDef", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:DecoratorParamDef)
@@ -2838,10 +2275,7 @@ impl<'buf> DecoratorParamDef<'buf> {
     self.default_value = option::Option::Some(value);
     self
   }
-  pub fn with_allowed_values(
-    mut self,
-    value: impl iter::IntoIterator<Item = LiteralValue<'buf>>,
-  ) -> Self {
+  pub fn with_allowed_values(mut self, value: impl iter::IntoIterator<Item = LiteralValue<'buf>>) -> Self {
     self.allowed_values = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -2853,16 +2287,16 @@ impl<'buf> DecoratorParamDef<'buf> {
 /// parameters it accepts, and optional Lua source for validate/export.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct DecoratorDef<'buf> {
-  /// Bitmask of DecoratorTarget values this decorator may apply to.
+/// Bitmask of DecoratorTarget values this decorator may apply to.
   pub targets: option::Option<DecoratorTarget>,
-  /// When true, the decorator can appear multiple times on the same target.
+/// When true, the decorator can appear multiple times on the same target.
   pub allow_multiple: option::Option<bool>,
   pub params: option::Option<vec::Vec<DecoratorParamDef<'buf>>>,
-  /// Lua source for validate block. Runs at compile time to reject invalid
-  /// usages. Absent when the decorator has no validate block.
+/// Lua source for validate block. Runs at compile time to reject invalid
+/// usages. Absent when the decorator has no validate block.
   pub validate_source: option::Option<borrow::Cow<'buf, str>>,
-  /// Lua source for export block. Produces key-value metadata stored in
-  /// DecoratorUsage.export_data. Absent when no export block.
+/// Lua source for export block. Produces key-value metadata stored in
+/// DecoratorUsage.export_data. Absent when no export block.
   pub export_source: option::Option<borrow::Cow<'buf, str>>,
 }
 
@@ -2873,15 +2307,9 @@ impl<'buf> DecoratorDef<'buf> {
     DecoratorDef {
       targets: self.targets,
       allow_multiple: self.allow_multiple,
-      params: self
-        .params
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
-      validate_source: self
-        .validate_source
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
-      export_source: self
-        .export_source
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      params: self.params.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      validate_source: self.validate_source.map(|v| borrow::Cow::Owned(v.into_owned())),
+      export_source: self.export_source.map(|v| borrow::Cow::Owned(v.into_owned())),
     }
   }
 }
@@ -2929,8 +2357,7 @@ impl<'buf> bebop::BebopEncode for DecoratorDef<'buf> {
       size += bebop::wire_size::tagged_size(mem::size_of::<bool>());
     }
     if let option::Option::Some(ref v) = self.params {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.validate_source {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
@@ -2952,49 +2379,14 @@ impl<'buf> bebop::BebopDecode<'buf> for DecoratorDef<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.targets = option::Option::Some(
-            DecoratorTarget::decode(reader).for_field("DecoratorDef", "targets")?,
-          )
-        }
-        2 => {
-          msg.allow_multiple = option::Option::Some(
-            reader
-              .read_bool()
-              .for_field("DecoratorDef", "allow_multiple")?,
-          )
-        }
-        3 => {
-          msg.params = option::Option::Some(
-            reader
-              .read_array(|_r| DecoratorParamDef::decode(_r))
-              .for_field("DecoratorDef", "params")?,
-          )
-        }
-        4 => {
-          msg.validate_source = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("DecoratorDef", "validate_source")?,
-          ))
-        }
-        5 => {
-          msg.export_source = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("DecoratorDef", "export_source")?,
-          ))
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "DecoratorDef",
-            tag,
-          });
-        }
+        1 => msg.targets = option::Option::Some(DecoratorTarget::decode(reader).for_field("DecoratorDef", "targets")?),
+        2 => msg.allow_multiple = option::Option::Some(reader.read_bool().for_field("DecoratorDef", "allow_multiple")?),
+        3 => msg.params = option::Option::Some(reader.read_array(|_r| DecoratorParamDef::decode(_r)).for_field("DecoratorDef", "params")?),
+        4 => msg.validate_source = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DecoratorDef", "validate_source")?)),
+        5 => msg.export_source = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DecoratorDef", "export_source")?)),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "DecoratorDef", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:DecoratorDef)
@@ -3011,10 +2403,7 @@ impl<'buf> DecoratorDef<'buf> {
     self.allow_multiple = option::Option::Some(value);
     self
   }
-  pub fn with_params(
-    mut self,
-    value: impl iter::IntoIterator<Item = DecoratorParamDef<'buf>>,
-  ) -> Self {
+  pub fn with_params(mut self, value: impl iter::IntoIterator<Item = DecoratorParamDef<'buf>>) -> Self {
     self.params = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -3040,15 +2429,15 @@ impl<'buf> DecoratorDef<'buf> {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct DefinitionDescriptor<'buf> {
   pub kind: option::Option<DefinitionKind>,
-  /// Simple name as declared in source.
+/// Simple name as declared in source.
   pub name: option::Option<borrow::Cow<'buf, str>>,
-  /// Fully-qualified name including package and parent scopes.
+/// Fully-qualified name including package and parent scopes.
   pub fqn: option::Option<borrow::Cow<'buf, str>>,
-  /// Text from preceding `///` comments in source.
+/// Text from preceding `///` comments in source.
   pub documentation: option::Option<borrow::Cow<'buf, str>>,
   pub visibility: option::Option<Visibility>,
   pub decorators: option::Option<vec::Vec<DecoratorUsage<'buf>>>,
-  /// Types declared inside this definition's body.
+/// Types declared inside this definition's body.
   pub nested: option::Option<vec::Vec<DefinitionDescriptor<'buf>>>,
   pub enum_def: option::Option<EnumDef<'buf>>,
   pub struct_def: option::Option<StructDef<'buf>>,
@@ -3067,16 +2456,10 @@ impl<'buf> DefinitionDescriptor<'buf> {
       kind: self.kind,
       name: self.name.map(|v| borrow::Cow::Owned(v.into_owned())),
       fqn: self.fqn.map(|v| borrow::Cow::Owned(v.into_owned())),
-      documentation: self
-        .documentation
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      documentation: self.documentation.map(|v| borrow::Cow::Owned(v.into_owned())),
       visibility: self.visibility,
-      decorators: self
-        .decorators
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
-      nested: self
-        .nested
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      decorators: self.decorators.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      nested: self.nested.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
       enum_def: self.enum_def.map(|v| v.into_owned()),
       struct_def: self.struct_def.map(|v| v.into_owned()),
       message_def: self.message_def.map(|v| v.into_owned()),
@@ -3176,12 +2559,10 @@ impl<'buf> bebop::BebopEncode for DefinitionDescriptor<'buf> {
       size += bebop::wire_size::tagged_size(v.encoded_size());
     }
     if let option::Option::Some(ref v) = self.decorators {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.nested {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.enum_def {
       size += bebop::wire_size::tagged_size(v.encoded_size());
@@ -3218,94 +2599,23 @@ impl<'buf> bebop::BebopDecode<'buf> for DefinitionDescriptor<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.kind = option::Option::Some(
-            DefinitionKind::decode(reader).for_field("DefinitionDescriptor", "kind")?,
-          )
-        }
-        2 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("DefinitionDescriptor", "name")?,
-          ))
-        }
-        3 => {
-          msg.fqn = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("DefinitionDescriptor", "fqn")?,
-          ))
-        }
-        4 => {
-          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("DefinitionDescriptor", "documentation")?,
-          ))
-        }
-        5 => {
-          msg.visibility = option::Option::Some(
-            Visibility::decode(reader).for_field("DefinitionDescriptor", "visibility")?,
-          )
-        }
-        6 => {
-          msg.decorators = option::Option::Some(
-            reader
-              .read_array(|_r| DecoratorUsage::decode(_r))
-              .for_field("DefinitionDescriptor", "decorators")?,
-          )
-        }
-        7 => {
-          msg.nested = option::Option::Some(
-            reader
-              .read_array(|_r| DefinitionDescriptor::decode(_r))
-              .for_field("DefinitionDescriptor", "nested")?,
-          )
-        }
-        8 => {
-          msg.enum_def = option::Option::Some(
-            EnumDef::decode(reader).for_field("DefinitionDescriptor", "enum_def")?,
-          )
-        }
-        9 => {
-          msg.struct_def = option::Option::Some(
-            StructDef::decode(reader).for_field("DefinitionDescriptor", "struct_def")?,
-          )
-        }
-        10 => {
-          msg.message_def = option::Option::Some(
-            MessageDef::decode(reader).for_field("DefinitionDescriptor", "message_def")?,
-          )
-        }
-        11 => {
-          msg.union_def = option::Option::Some(
-            UnionDef::decode(reader).for_field("DefinitionDescriptor", "union_def")?,
-          )
-        }
-        12 => {
-          msg.service_def = option::Option::Some(
-            ServiceDef::decode(reader).for_field("DefinitionDescriptor", "service_def")?,
-          )
-        }
-        13 => {
-          msg.const_def = option::Option::Some(
-            ConstDef::decode(reader).for_field("DefinitionDescriptor", "const_def")?,
-          )
-        }
-        14 => {
-          msg.decorator_def = option::Option::Some(
-            DecoratorDef::decode(reader).for_field("DefinitionDescriptor", "decorator_def")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "DefinitionDescriptor",
-            tag,
-          });
-        }
+        1 => msg.kind = option::Option::Some(DefinitionKind::decode(reader).for_field("DefinitionDescriptor", "kind")?),
+        2 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DefinitionDescriptor", "name")?)),
+        3 => msg.fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DefinitionDescriptor", "fqn")?)),
+        4 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("DefinitionDescriptor", "documentation")?)),
+        5 => msg.visibility = option::Option::Some(Visibility::decode(reader).for_field("DefinitionDescriptor", "visibility")?),
+        6 => msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r)).for_field("DefinitionDescriptor", "decorators")?),
+        7 => msg.nested = option::Option::Some(reader.read_array(|_r| DefinitionDescriptor::decode(_r)).for_field("DefinitionDescriptor", "nested")?),
+        8 => msg.enum_def = option::Option::Some(EnumDef::decode(reader).for_field("DefinitionDescriptor", "enum_def")?),
+        9 => msg.struct_def = option::Option::Some(StructDef::decode(reader).for_field("DefinitionDescriptor", "struct_def")?),
+        10 => msg.message_def = option::Option::Some(MessageDef::decode(reader).for_field("DefinitionDescriptor", "message_def")?),
+        11 => msg.union_def = option::Option::Some(UnionDef::decode(reader).for_field("DefinitionDescriptor", "union_def")?),
+        12 => msg.service_def = option::Option::Some(ServiceDef::decode(reader).for_field("DefinitionDescriptor", "service_def")?),
+        13 => msg.const_def = option::Option::Some(ConstDef::decode(reader).for_field("DefinitionDescriptor", "const_def")?),
+        14 => msg.decorator_def = option::Option::Some(DecoratorDef::decode(reader).for_field("DefinitionDescriptor", "decorator_def")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "DefinitionDescriptor", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:DefinitionDescriptor)
@@ -3334,17 +2644,11 @@ impl<'buf> DefinitionDescriptor<'buf> {
     self.visibility = option::Option::Some(value);
     self
   }
-  pub fn with_decorators(
-    mut self,
-    value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>,
-  ) -> Self {
+  pub fn with_decorators(mut self, value: impl iter::IntoIterator<Item = DecoratorUsage<'buf>>) -> Self {
     self.decorators = option::Option::Some(value.into_iter().collect());
     self
   }
-  pub fn with_nested(
-    mut self,
-    value: impl iter::IntoIterator<Item = DefinitionDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_nested(mut self, value: impl iter::IntoIterator<Item = DefinitionDescriptor<'buf>>) -> Self {
     self.nested = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -3384,24 +2688,24 @@ impl<'buf> DefinitionDescriptor<'buf> {
 /// error reporting, documentation extraction, and IDE features.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Location<'buf> {
-  /// Path into the descriptor tree. Encoded as pairs of (field_tag, index):
-  /// ```
-  /// [5, 0]       -> schema.definitions[0]
-  /// [5, 0, 1, 2] -> schema.definitions[0].fields[2]
-  /// [5, 1, 2, 0] -> schema.definitions[1].members[0]
-  /// ```
-  /// Field tags correspond to definition body field indices
-  /// (StructDef.fields = 1, EnumDef.members = 2, etc.).
+/// Path into the descriptor tree. Encoded as pairs of (field_tag, index):
+/// ```
+/// [5, 0]       -> schema.definitions[0]
+/// [5, 0, 1, 2] -> schema.definitions[0].fields[2]
+/// [5, 1, 2, 0] -> schema.definitions[1].members[0]
+/// ```
+/// Field tags correspond to definition body field indices
+/// (StructDef.fields = 1, EnumDef.members = 2, etc.).
   pub path: option::Option<borrow::Cow<'buf, [i32]>>,
-  /// Source span as `[start_line, start_col, end_line, end_col]`.
-  /// All values 1-based. Columns count characters, tabs advance to
-  /// next multiple of 4.
+/// Source span as `[start_line, start_col, end_line, end_col]`.
+/// All values 1-based. Columns count characters, tabs advance to
+/// next multiple of 4.
   pub span: option::Option<[i32; 4]>,
-  /// Comments on adjacent preceding lines with no blank line separation.
+/// Comments on adjacent preceding lines with no blank line separation.
   pub leading_comments: option::Option<borrow::Cow<'buf, str>>,
-  /// Comment on the same line after the element or after an opening brace.
+/// Comment on the same line after the element or after an opening brace.
   pub trailing_comments: option::Option<borrow::Cow<'buf, str>>,
-  /// Comment groups separated from the element by blank lines.
+/// Comment groups separated from the element by blank lines.
   pub detached_comments: option::Option<vec::Vec<borrow::Cow<'buf, str>>>,
 }
 
@@ -3412,17 +2716,9 @@ impl<'buf> Location<'buf> {
     Location {
       path: self.path.map(|v| borrow::Cow::Owned(v.into_owned())),
       span: self.span,
-      leading_comments: self
-        .leading_comments
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
-      trailing_comments: self
-        .trailing_comments
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
-      detached_comments: self.detached_comments.map(|v| {
-        v.into_iter()
-          .map(|_e| borrow::Cow::Owned(_e.into_owned()))
-          .collect()
-      }),
+      leading_comments: self.leading_comments.map(|v| borrow::Cow::Owned(v.into_owned())),
+      trailing_comments: self.trailing_comments.map(|v| borrow::Cow::Owned(v.into_owned())),
+      detached_comments: self.detached_comments.map(|v| v.into_iter().map(|_e| borrow::Cow::Owned(_e.into_owned())).collect()),
     }
   }
 }
@@ -3464,9 +2760,7 @@ impl<'buf> bebop::BebopEncode for Location<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.path {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| {
-        (mem::size_of::<i32>())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| (mem::size_of::<i32>())));
     }
     if let option::Option::Some(ref v) = self.span {
       size += bebop::wire_size::tagged_size(4usize * (mem::size_of::<i32>()));
@@ -3478,9 +2772,7 @@ impl<'buf> bebop::BebopEncode for Location<'buf> {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
     }
     if let option::Option::Some(ref v) = self.detached_comments {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| {
-        bebop::wire_size::string_size(_el.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| bebop::wire_size::string_size(_el.len())));
     }
     size
   }
@@ -3496,51 +2788,14 @@ impl<'buf> bebop::BebopDecode<'buf> for Location<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.path = option::Option::Some(
-            reader
-              .read_scalar_array::<i32>()
-              .for_field("Location", "path")?,
-          )
-        }
-        2 => {
-          msg.span = option::Option::Some(
-            reader
-              .read_fixed_array::<i32, 4>()
-              .for_field("Location", "span")?,
-          )
-        }
-        3 => {
-          msg.leading_comments = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("Location", "leading_comments")?,
-          ))
-        }
-        4 => {
-          msg.trailing_comments = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("Location", "trailing_comments")?,
-          ))
-        }
-        5 => {
-          msg.detached_comments = option::Option::Some(
-            reader
-              .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
-              .for_field("Location", "detached_comments")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "Location",
-            tag,
-          });
-        }
+        1 => msg.path = option::Option::Some(reader.read_scalar_array::<i32>().for_field("Location", "path")?),
+        2 => msg.span = option::Option::Some(reader.read_fixed_array::<i32, 4>().for_field("Location", "span")?),
+        3 => msg.leading_comments = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Location", "leading_comments")?)),
+        4 => msg.trailing_comments = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Location", "trailing_comments")?)),
+        5 => msg.detached_comments = option::Option::Some(reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))).for_field("Location", "detached_comments")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "Location", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:Location)
@@ -3557,24 +2812,15 @@ impl<'buf> Location<'buf> {
     self.span = option::Option::Some(value);
     self
   }
-  pub fn with_leading_comments(
-    mut self,
-    value: impl convert::Into<borrow::Cow<'buf, str>>,
-  ) -> Self {
+  pub fn with_leading_comments(mut self, value: impl convert::Into<borrow::Cow<'buf, str>>) -> Self {
     self.leading_comments = option::Option::Some(value.into());
     self
   }
-  pub fn with_trailing_comments(
-    mut self,
-    value: impl convert::Into<borrow::Cow<'buf, str>>,
-  ) -> Self {
+  pub fn with_trailing_comments(mut self, value: impl convert::Into<borrow::Cow<'buf, str>>) -> Self {
     self.trailing_comments = option::Option::Some(value.into());
     self
   }
-  pub fn with_detached_comments(
-    mut self,
-    value: impl iter::IntoIterator<Item = impl convert::Into<borrow::Cow<'buf, str>>>,
-  ) -> Self {
+  pub fn with_detached_comments(mut self, value: impl iter::IntoIterator<Item = impl convert::Into<borrow::Cow<'buf, str>>>) -> Self {
     self.detached_comments = option::Option::Some(value.into_iter().map(|_e| _e.into()).collect());
     self
   }
@@ -3595,9 +2841,7 @@ pub type SourceCodeInfoOwned = SourceCodeInfo<'static>;
 impl<'buf> SourceCodeInfo<'buf> {
   pub fn into_owned(self) -> SourceCodeInfoOwned {
     SourceCodeInfo {
-      locations: self
-        .locations
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      locations: self.locations.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -3623,8 +2867,7 @@ impl<'buf> bebop::BebopEncode for SourceCodeInfo<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.locations {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -3640,23 +2883,10 @@ impl<'buf> bebop::BebopDecode<'buf> for SourceCodeInfo<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.locations = option::Option::Some(
-            reader
-              .read_array(|_r| Location::decode(_r))
-              .for_field("SourceCodeInfo", "locations")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "SourceCodeInfo",
-            tag,
-          });
-        }
+        1 => msg.locations = option::Option::Some(reader.read_array(|_r| Location::decode(_r)).for_field("SourceCodeInfo", "locations")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "SourceCodeInfo", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:SourceCodeInfo)
@@ -3678,16 +2908,16 @@ impl<'buf> SourceCodeInfo<'buf> {
 /// Generators can emit types in array order without forward declarations.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct SchemaDescriptor<'buf> {
-  /// File path as provided to the compiler.
+/// File path as provided to the compiler.
   pub path: option::Option<borrow::Cow<'buf, str>>,
-  /// Package declaration from source. Absent when no package is declared.
+/// Package declaration from source. Absent when no package is declared.
   pub package: option::Option<borrow::Cow<'buf, str>>,
   pub edition: option::Option<Edition>,
-  /// Import paths in source declaration order.
+/// Import paths in source declaration order.
   pub imports: option::Option<vec::Vec<borrow::Cow<'buf, str>>>,
-  /// All definitions in topological dependency order.
+/// All definitions in topological dependency order.
   pub definitions: option::Option<vec::Vec<DefinitionDescriptor<'buf>>>,
-  /// Source code info. Only present when requested during compilation.
+/// Source code info. Only present when requested during compilation.
   pub source_code_info: option::Option<SourceCodeInfo<'buf>>,
 }
 
@@ -3699,14 +2929,8 @@ impl<'buf> SchemaDescriptor<'buf> {
       path: self.path.map(|v| borrow::Cow::Owned(v.into_owned())),
       package: self.package.map(|v| borrow::Cow::Owned(v.into_owned())),
       edition: self.edition,
-      imports: self.imports.map(|v| {
-        v.into_iter()
-          .map(|_e| borrow::Cow::Owned(_e.into_owned()))
-          .collect()
-      }),
-      definitions: self
-        .definitions
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      imports: self.imports.map(|v| v.into_iter().map(|_e| borrow::Cow::Owned(_e.into_owned())).collect()),
+      definitions: self.definitions.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
       source_code_info: self.source_code_info.map(|v| v.into_owned()),
     }
   }
@@ -3762,13 +2986,10 @@ impl<'buf> bebop::BebopEncode for SchemaDescriptor<'buf> {
       size += bebop::wire_size::tagged_size(v.encoded_size());
     }
     if let option::Option::Some(ref v) = self.imports {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| {
-        bebop::wire_size::string_size(_el.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| bebop::wire_size::string_size(_el.len())));
     }
     if let option::Option::Some(ref v) = self.definitions {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.source_code_info {
       size += bebop::wire_size::tagged_size(v.encoded_size());
@@ -3787,49 +3008,15 @@ impl<'buf> bebop::BebopDecode<'buf> for SchemaDescriptor<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.path = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("SchemaDescriptor", "path")?,
-          ))
-        }
-        2 => {
-          msg.package = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("SchemaDescriptor", "package")?,
-          ))
-        }
-        3 => {
-          msg.edition =
-            option::Option::Some(Edition::decode(reader).for_field("SchemaDescriptor", "edition")?)
-        }
-        4 => {
-          msg.imports = option::Option::Some(
-            reader
-              .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
-              .for_field("SchemaDescriptor", "imports")?,
-          )
-        }
-        5 => {
-          msg.definitions = option::Option::Some(
-            reader
-              .read_array(|_r| DefinitionDescriptor::decode(_r))
-              .for_field("SchemaDescriptor", "definitions")?,
-          )
-        }
-        6 => {
-          msg.source_code_info = option::Option::Some(
-            SourceCodeInfo::decode(reader).for_field("SchemaDescriptor", "source_code_info")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "SchemaDescriptor",
-            tag,
-          });
-        }
+        1 => msg.path = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("SchemaDescriptor", "path")?)),
+        2 => msg.package = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("SchemaDescriptor", "package")?)),
+        3 => msg.edition = option::Option::Some(Edition::decode(reader).for_field("SchemaDescriptor", "edition")?),
+        4 => msg.imports = option::Option::Some(reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))).for_field("SchemaDescriptor", "imports")?),
+        5 => msg.definitions = option::Option::Some(reader.read_array(|_r| DefinitionDescriptor::decode(_r)).for_field("SchemaDescriptor", "definitions")?),
+        6 => msg.source_code_info = option::Option::Some(SourceCodeInfo::decode(reader).for_field("SchemaDescriptor", "source_code_info")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "SchemaDescriptor", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:SchemaDescriptor)
@@ -3850,17 +3037,11 @@ impl<'buf> SchemaDescriptor<'buf> {
     self.edition = option::Option::Some(value);
     self
   }
-  pub fn with_imports(
-    mut self,
-    value: impl iter::IntoIterator<Item = impl convert::Into<borrow::Cow<'buf, str>>>,
-  ) -> Self {
+  pub fn with_imports(mut self, value: impl iter::IntoIterator<Item = impl convert::Into<borrow::Cow<'buf, str>>>) -> Self {
     self.imports = option::Option::Some(value.into_iter().map(|_e| _e.into()).collect());
     self
   }
-  pub fn with_definitions(
-    mut self,
-    value: impl iter::IntoIterator<Item = DefinitionDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_definitions(mut self, value: impl iter::IntoIterator<Item = DefinitionDescriptor<'buf>>) -> Self {
     self.definitions = option::Option::Some(value.into_iter().collect());
     self
   }
@@ -3886,9 +3067,7 @@ pub type DescriptorSetOwned = DescriptorSet<'static>;
 impl<'buf> DescriptorSet<'buf> {
   pub fn into_owned(self) -> DescriptorSetOwned {
     DescriptorSet {
-      schemas: self
-        .schemas
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      schemas: self.schemas.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -3914,8 +3093,7 @@ impl<'buf> bebop::BebopEncode for DescriptorSet<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.schemas {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -3931,23 +3109,10 @@ impl<'buf> bebop::BebopDecode<'buf> for DescriptorSet<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.schemas = option::Option::Some(
-            reader
-              .read_array(|_r| SchemaDescriptor::decode(_r))
-              .for_field("DescriptorSet", "schemas")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "DescriptorSet",
-            tag,
-          });
-        }
+        1 => msg.schemas = option::Option::Some(reader.read_array(|_r| SchemaDescriptor::decode(_r)).for_field("DescriptorSet", "schemas")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "DescriptorSet", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:DescriptorSet)
@@ -3956,10 +3121,7 @@ impl<'buf> bebop::BebopDecode<'buf> for DescriptorSet<'buf> {
 }
 
 impl<'buf> DescriptorSet<'buf> {
-  pub fn with_schemas(
-    mut self,
-    value: impl iter::IntoIterator<Item = SchemaDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_schemas(mut self, value: impl iter::IntoIterator<Item = SchemaDescriptor<'buf>>) -> Self {
     self.schemas = option::Option::Some(value.into_iter().collect());
     self
   }

--- a/plugins/rust/src/generated/descriptor.rs
+++ b/plugins/rust/src/generated/descriptor.rs
@@ -17,6 +17,7 @@ extern crate bebop_runtime;
 extern crate core;
 use alloc::{borrow, boxed, string, vec};
 use bebop_runtime as bebop;
+use bebop_runtime::DecodeContext as _;
 use core::convert::Into as _;
 use core::iter::{IntoIterator as _, Iterator as _};
 use core::{convert, default, iter, mem, ops, option, result};
@@ -683,18 +684,44 @@ impl<'buf> bebop::BebopDecode<'buf> for TypeDescriptor<'buf> {
         break;
       }
       match tag {
-        1 => msg.kind = option::Option::Some(TypeKind::decode(reader)?),
+        1 => {
+          msg.kind =
+            option::Option::Some(TypeKind::decode(reader).for_field("TypeDescriptor", "kind")?)
+        }
         2 => {
-          msg.array_element = option::Option::Some(boxed::Box::new(TypeDescriptor::decode(reader)?))
+          msg.array_element = option::Option::Some(boxed::Box::new(
+            TypeDescriptor::decode(reader).for_field("TypeDescriptor", "array_element")?,
+          ))
         }
         3 => {
-          msg.fixed_array_element =
-            option::Option::Some(boxed::Box::new(TypeDescriptor::decode(reader)?))
+          msg.fixed_array_element = option::Option::Some(boxed::Box::new(
+            TypeDescriptor::decode(reader).for_field("TypeDescriptor", "fixed_array_element")?,
+          ))
         }
-        4 => msg.fixed_array_size = option::Option::Some(reader.read_u32()?),
-        5 => msg.map_key = option::Option::Some(boxed::Box::new(TypeDescriptor::decode(reader)?)),
-        6 => msg.map_value = option::Option::Some(boxed::Box::new(TypeDescriptor::decode(reader)?)),
-        7 => msg.defined_fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        4 => {
+          msg.fixed_array_size = option::Option::Some(
+            reader
+              .read_u32()
+              .for_field("TypeDescriptor", "fixed_array_size")?,
+          )
+        }
+        5 => {
+          msg.map_key = option::Option::Some(boxed::Box::new(
+            TypeDescriptor::decode(reader).for_field("TypeDescriptor", "map_key")?,
+          ))
+        }
+        6 => {
+          msg.map_value = option::Option::Some(boxed::Box::new(
+            TypeDescriptor::decode(reader).for_field("TypeDescriptor", "map_value")?,
+          ))
+        }
+        7 => {
+          msg.defined_fqn = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("TypeDescriptor", "defined_fqn")?,
+          ))
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "TypeDescriptor",
@@ -889,19 +916,59 @@ impl<'buf> bebop::BebopDecode<'buf> for LiteralValue<'buf> {
         break;
       }
       match tag {
-        1 => msg.kind = option::Option::Some(LiteralKind::decode(reader)?),
-        2 => msg.bool_value = option::Option::Some(reader.read_bool()?),
-        3 => msg.int_value = option::Option::Some(reader.read_i64()?),
-        4 => msg.float_value = option::Option::Some(reader.read_f64()?),
-        5 => msg.string_value = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        6 => msg.uuid_value = option::Option::Some(reader.read_uuid()?),
-        7 => msg.raw_value = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        8 => {
-          msg.bytes_value =
-            option::Option::Some(bebop::BebopBytes::borrowed(reader.read_byte_slice()?))
+        1 => {
+          msg.kind =
+            option::Option::Some(LiteralKind::decode(reader).for_field("LiteralValue", "kind")?)
         }
-        9 => msg.timestamp_value = option::Option::Some(reader.read_timestamp()?),
-        10 => msg.duration_value = option::Option::Some(reader.read_duration()?),
+        2 => {
+          msg.bool_value =
+            option::Option::Some(reader.read_bool().for_field("LiteralValue", "bool_value")?)
+        }
+        3 => {
+          msg.int_value =
+            option::Option::Some(reader.read_i64().for_field("LiteralValue", "int_value")?)
+        }
+        4 => {
+          msg.float_value =
+            option::Option::Some(reader.read_f64().for_field("LiteralValue", "float_value")?)
+        }
+        5 => {
+          msg.string_value = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("LiteralValue", "string_value")?,
+          ))
+        }
+        6 => {
+          msg.uuid_value =
+            option::Option::Some(reader.read_uuid().for_field("LiteralValue", "uuid_value")?)
+        }
+        7 => {
+          msg.raw_value = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("LiteralValue", "raw_value")?,
+          ))
+        }
+        8 => {
+          msg.bytes_value = option::Option::Some(bebop::BebopBytes::borrowed(
+            reader
+              .read_byte_slice()
+              .for_field("LiteralValue", "bytes_value")?,
+          ))
+        }
+        9 => {
+          msg.timestamp_value = option::Option::Some(
+            reader
+              .read_timestamp()
+              .for_field("LiteralValue", "timestamp_value")?,
+          )
+        }
+        10 => {
+          msg.duration_value = option::Option::Some(
+            reader
+              .read_duration()
+              .for_field("LiteralValue", "duration_value")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "LiteralValue",
@@ -1008,8 +1075,8 @@ impl<'buf> bebop::BebopDecode<'buf> for DecoratorArg<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:DecoratorArg)
-    let name = borrow::Cow::Borrowed(reader.read_str()?);
-    let value = LiteralValue::decode(reader)?;
+    let name = borrow::Cow::Borrowed(reader.read_str().for_field("DecoratorArg", "name")?);
+    let value = LiteralValue::decode(reader).for_field("DecoratorArg", "value")?;
     // @@bebop_insertion_point(decode_end:DecoratorArg)
     result::Result::Ok(DecoratorArg { name, value })
   }
@@ -1114,15 +1181,29 @@ impl<'buf> bebop::BebopDecode<'buf> for DecoratorUsage<'buf> {
         break;
       }
       match tag {
-        1 => msg.fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.args = option::Option::Some(reader.read_array(|_r| DecoratorArg::decode(_r))?),
+        1 => {
+          msg.fqn = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("DecoratorUsage", "fqn")?,
+          ))
+        }
+        2 => {
+          msg.args = option::Option::Some(
+            reader
+              .read_array(|_r| DecoratorArg::decode(_r))
+              .for_field("DecoratorUsage", "args")?,
+          )
+        }
         3 => {
-          msg.export_data = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              LiteralValue::decode(_r)?,
-            ))
-          })?)
+          msg.export_data = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  LiteralValue::decode(_r)?,
+                ))
+              })
+              .for_field("DecoratorUsage", "export_data")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -1267,12 +1348,32 @@ impl<'buf> bebop::BebopDecode<'buf> for FieldDescriptor<'buf> {
         break;
       }
       match tag {
-        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.r#type = option::Option::Some(TypeDescriptor::decode(reader)?),
-        4 => msg.index = option::Option::Some(reader.read_u32()?),
+        1 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("FieldDescriptor", "name")?,
+          ))
+        }
+        2 => {
+          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("FieldDescriptor", "documentation")?,
+          ))
+        }
+        3 => {
+          msg.r#type = option::Option::Some(
+            TypeDescriptor::decode(reader).for_field("FieldDescriptor", "type")?,
+          )
+        }
+        4 => {
+          msg.index = option::Option::Some(reader.read_u32().for_field("FieldDescriptor", "index")?)
+        }
         5 => {
-          msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r))?)
+          msg.decorators = option::Option::Some(
+            reader
+              .read_array(|_r| DecoratorUsage::decode(_r))
+              .for_field("FieldDescriptor", "decorators")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -1417,13 +1518,41 @@ impl<'buf> bebop::BebopDecode<'buf> for EnumMemberDescriptor<'buf> {
         break;
       }
       match tag {
-        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.value = option::Option::Some(reader.read_u64()?),
-        4 => {
-          msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r))?)
+        1 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("EnumMemberDescriptor", "name")?,
+          ))
         }
-        5 => msg.value_expr = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        2 => {
+          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("EnumMemberDescriptor", "documentation")?,
+          ))
+        }
+        3 => {
+          msg.value = option::Option::Some(
+            reader
+              .read_u64()
+              .for_field("EnumMemberDescriptor", "value")?,
+          )
+        }
+        4 => {
+          msg.decorators = option::Option::Some(
+            reader
+              .read_array(|_r| DecoratorUsage::decode(_r))
+              .for_field("EnumMemberDescriptor", "decorators")?,
+          )
+        }
+        5 => {
+          msg.value_expr = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("EnumMemberDescriptor", "value_expr")?,
+          ))
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "EnumMemberDescriptor",
@@ -1590,13 +1719,47 @@ impl<'buf> bebop::BebopDecode<'buf> for UnionBranchDescriptor<'buf> {
         break;
       }
       match tag {
-        1 => msg.discriminator = option::Option::Some(reader.read_byte()?),
-        2 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.inline_fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        4 => msg.type_ref_fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        5 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        1 => {
+          msg.discriminator = option::Option::Some(
+            reader
+              .read_byte()
+              .for_field("UnionBranchDescriptor", "discriminator")?,
+          )
+        }
+        2 => {
+          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("UnionBranchDescriptor", "documentation")?,
+          ))
+        }
+        3 => {
+          msg.inline_fqn = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("UnionBranchDescriptor", "inline_fqn")?,
+          ))
+        }
+        4 => {
+          msg.type_ref_fqn = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("UnionBranchDescriptor", "type_ref_fqn")?,
+          ))
+        }
+        5 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("UnionBranchDescriptor", "name")?,
+          ))
+        }
         6 => {
-          msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r))?)
+          msg.decorators = option::Option::Some(
+            reader
+              .read_array(|_r| DecoratorUsage::decode(_r))
+              .for_field("UnionBranchDescriptor", "decorators")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -1761,14 +1924,40 @@ impl<'buf> bebop::BebopDecode<'buf> for MethodDescriptor<'buf> {
         break;
       }
       match tag {
-        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.request_type = option::Option::Some(TypeDescriptor::decode(reader)?),
-        4 => msg.response_type = option::Option::Some(TypeDescriptor::decode(reader)?),
-        5 => msg.method_type = option::Option::Some(MethodType::decode(reader)?),
-        6 => msg.id = option::Option::Some(reader.read_u32()?),
+        1 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("MethodDescriptor", "name")?,
+          ))
+        }
+        2 => {
+          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("MethodDescriptor", "documentation")?,
+          ))
+        }
+        3 => {
+          msg.request_type = option::Option::Some(
+            TypeDescriptor::decode(reader).for_field("MethodDescriptor", "request_type")?,
+          )
+        }
+        4 => {
+          msg.response_type = option::Option::Some(
+            TypeDescriptor::decode(reader).for_field("MethodDescriptor", "response_type")?,
+          )
+        }
+        5 => {
+          msg.method_type = option::Option::Some(
+            MethodType::decode(reader).for_field("MethodDescriptor", "method_type")?,
+          )
+        }
+        6 => msg.id = option::Option::Some(reader.read_u32().for_field("MethodDescriptor", "id")?),
         7 => {
-          msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r))?)
+          msg.decorators = option::Option::Some(
+            reader
+              .read_array(|_r| DecoratorUsage::decode(_r))
+              .for_field("MethodDescriptor", "decorators")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -1901,12 +2090,20 @@ impl<'buf> bebop::BebopDecode<'buf> for EnumDef<'buf> {
         break;
       }
       match tag {
-        1 => msg.base_type = option::Option::Some(TypeKind::decode(reader)?),
-        2 => {
-          msg.members =
-            option::Option::Some(reader.read_array(|_r| EnumMemberDescriptor::decode(_r))?)
+        1 => {
+          msg.base_type =
+            option::Option::Some(TypeKind::decode(reader).for_field("EnumDef", "base_type")?)
         }
-        3 => msg.is_flags = option::Option::Some(reader.read_bool()?),
+        2 => {
+          msg.members = option::Option::Some(
+            reader
+              .read_array(|_r| EnumMemberDescriptor::decode(_r))
+              .for_field("EnumDef", "members")?,
+          )
+        }
+        3 => {
+          msg.is_flags = option::Option::Some(reader.read_bool().for_field("EnumDef", "is_flags")?)
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "EnumDef",
@@ -2024,10 +2221,20 @@ impl<'buf> bebop::BebopDecode<'buf> for StructDef<'buf> {
       }
       match tag {
         1 => {
-          msg.fields = option::Option::Some(reader.read_array(|_r| FieldDescriptor::decode(_r))?)
+          msg.fields = option::Option::Some(
+            reader
+              .read_array(|_r| FieldDescriptor::decode(_r))
+              .for_field("StructDef", "fields")?,
+          )
         }
-        2 => msg.is_mutable = option::Option::Some(reader.read_bool()?),
-        3 => msg.fixed_size = option::Option::Some(reader.read_u32()?),
+        2 => {
+          msg.is_mutable =
+            option::Option::Some(reader.read_bool().for_field("StructDef", "is_mutable")?)
+        }
+        3 => {
+          msg.fixed_size =
+            option::Option::Some(reader.read_u32().for_field("StructDef", "fixed_size")?)
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "StructDef",
@@ -2123,7 +2330,11 @@ impl<'buf> bebop::BebopDecode<'buf> for MessageDef<'buf> {
       }
       match tag {
         1 => {
-          msg.fields = option::Option::Some(reader.read_array(|_r| FieldDescriptor::decode(_r))?)
+          msg.fields = option::Option::Some(
+            reader
+              .read_array(|_r| FieldDescriptor::decode(_r))
+              .for_field("MessageDef", "fields")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -2212,8 +2423,11 @@ impl<'buf> bebop::BebopDecode<'buf> for UnionDef<'buf> {
       }
       match tag {
         1 => {
-          msg.branches =
-            option::Option::Some(reader.read_array(|_r| UnionBranchDescriptor::decode(_r))?)
+          msg.branches = option::Option::Some(
+            reader
+              .read_array(|_r| UnionBranchDescriptor::decode(_r))
+              .for_field("UnionDef", "branches")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -2300,7 +2514,11 @@ impl<'buf> bebop::BebopDecode<'buf> for ServiceDef<'buf> {
       }
       match tag {
         1 => {
-          msg.methods = option::Option::Some(reader.read_array(|_r| MethodDescriptor::decode(_r))?)
+          msg.methods = option::Option::Some(
+            reader
+              .read_array(|_r| MethodDescriptor::decode(_r))
+              .for_field("ServiceDef", "methods")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -2399,8 +2617,14 @@ impl<'buf> bebop::BebopDecode<'buf> for ConstDef<'buf> {
         break;
       }
       match tag {
-        1 => msg.r#type = option::Option::Some(TypeDescriptor::decode(reader)?),
-        2 => msg.value = option::Option::Some(LiteralValue::decode(reader)?),
+        1 => {
+          msg.r#type =
+            option::Option::Some(TypeDescriptor::decode(reader).for_field("ConstDef", "type")?)
+        }
+        2 => {
+          msg.value =
+            option::Option::Some(LiteralValue::decode(reader).for_field("ConstDef", "value")?)
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "ConstDef",
@@ -2545,14 +2769,40 @@ impl<'buf> bebop::BebopDecode<'buf> for DecoratorParamDef<'buf> {
         break;
       }
       match tag {
-        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.description = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.r#type = option::Option::Some(TypeKind::decode(reader)?),
-        4 => msg.required = option::Option::Some(reader.read_bool()?),
-        5 => msg.default_value = option::Option::Some(LiteralValue::decode(reader)?),
+        1 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("DecoratorParamDef", "name")?,
+          ))
+        }
+        2 => {
+          msg.description = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("DecoratorParamDef", "description")?,
+          ))
+        }
+        3 => {
+          msg.r#type =
+            option::Option::Some(TypeKind::decode(reader).for_field("DecoratorParamDef", "type")?)
+        }
+        4 => {
+          msg.required = option::Option::Some(
+            reader
+              .read_bool()
+              .for_field("DecoratorParamDef", "required")?,
+          )
+        }
+        5 => {
+          msg.default_value = option::Option::Some(
+            LiteralValue::decode(reader).for_field("DecoratorParamDef", "default_value")?,
+          )
+        }
         6 => {
-          msg.allowed_values =
-            option::Option::Some(reader.read_array(|_r| LiteralValue::decode(_r))?)
+          msg.allowed_values = option::Option::Some(
+            reader
+              .read_array(|_r| LiteralValue::decode(_r))
+              .for_field("DecoratorParamDef", "allowed_values")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -2706,13 +2956,39 @@ impl<'buf> bebop::BebopDecode<'buf> for DecoratorDef<'buf> {
         break;
       }
       match tag {
-        1 => msg.targets = option::Option::Some(DecoratorTarget::decode(reader)?),
-        2 => msg.allow_multiple = option::Option::Some(reader.read_bool()?),
-        3 => {
-          msg.params = option::Option::Some(reader.read_array(|_r| DecoratorParamDef::decode(_r))?)
+        1 => {
+          msg.targets = option::Option::Some(
+            DecoratorTarget::decode(reader).for_field("DecoratorDef", "targets")?,
+          )
         }
-        4 => msg.validate_source = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        5 => msg.export_source = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        2 => {
+          msg.allow_multiple = option::Option::Some(
+            reader
+              .read_bool()
+              .for_field("DecoratorDef", "allow_multiple")?,
+          )
+        }
+        3 => {
+          msg.params = option::Option::Some(
+            reader
+              .read_array(|_r| DecoratorParamDef::decode(_r))
+              .for_field("DecoratorDef", "params")?,
+          )
+        }
+        4 => {
+          msg.validate_source = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("DecoratorDef", "validate_source")?,
+          ))
+        }
+        5 => {
+          msg.export_source = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("DecoratorDef", "export_source")?,
+          ))
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "DecoratorDef",
@@ -2946,25 +3222,84 @@ impl<'buf> bebop::BebopDecode<'buf> for DefinitionDescriptor<'buf> {
         break;
       }
       match tag {
-        1 => msg.kind = option::Option::Some(DefinitionKind::decode(reader)?),
-        2 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.fqn = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        4 => msg.documentation = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        5 => msg.visibility = option::Option::Some(Visibility::decode(reader)?),
+        1 => {
+          msg.kind = option::Option::Some(
+            DefinitionKind::decode(reader).for_field("DefinitionDescriptor", "kind")?,
+          )
+        }
+        2 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("DefinitionDescriptor", "name")?,
+          ))
+        }
+        3 => {
+          msg.fqn = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("DefinitionDescriptor", "fqn")?,
+          ))
+        }
+        4 => {
+          msg.documentation = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("DefinitionDescriptor", "documentation")?,
+          ))
+        }
+        5 => {
+          msg.visibility = option::Option::Some(
+            Visibility::decode(reader).for_field("DefinitionDescriptor", "visibility")?,
+          )
+        }
         6 => {
-          msg.decorators = option::Option::Some(reader.read_array(|_r| DecoratorUsage::decode(_r))?)
+          msg.decorators = option::Option::Some(
+            reader
+              .read_array(|_r| DecoratorUsage::decode(_r))
+              .for_field("DefinitionDescriptor", "decorators")?,
+          )
         }
         7 => {
-          msg.nested =
-            option::Option::Some(reader.read_array(|_r| DefinitionDescriptor::decode(_r))?)
+          msg.nested = option::Option::Some(
+            reader
+              .read_array(|_r| DefinitionDescriptor::decode(_r))
+              .for_field("DefinitionDescriptor", "nested")?,
+          )
         }
-        8 => msg.enum_def = option::Option::Some(EnumDef::decode(reader)?),
-        9 => msg.struct_def = option::Option::Some(StructDef::decode(reader)?),
-        10 => msg.message_def = option::Option::Some(MessageDef::decode(reader)?),
-        11 => msg.union_def = option::Option::Some(UnionDef::decode(reader)?),
-        12 => msg.service_def = option::Option::Some(ServiceDef::decode(reader)?),
-        13 => msg.const_def = option::Option::Some(ConstDef::decode(reader)?),
-        14 => msg.decorator_def = option::Option::Some(DecoratorDef::decode(reader)?),
+        8 => {
+          msg.enum_def = option::Option::Some(
+            EnumDef::decode(reader).for_field("DefinitionDescriptor", "enum_def")?,
+          )
+        }
+        9 => {
+          msg.struct_def = option::Option::Some(
+            StructDef::decode(reader).for_field("DefinitionDescriptor", "struct_def")?,
+          )
+        }
+        10 => {
+          msg.message_def = option::Option::Some(
+            MessageDef::decode(reader).for_field("DefinitionDescriptor", "message_def")?,
+          )
+        }
+        11 => {
+          msg.union_def = option::Option::Some(
+            UnionDef::decode(reader).for_field("DefinitionDescriptor", "union_def")?,
+          )
+        }
+        12 => {
+          msg.service_def = option::Option::Some(
+            ServiceDef::decode(reader).for_field("DefinitionDescriptor", "service_def")?,
+          )
+        }
+        13 => {
+          msg.const_def = option::Option::Some(
+            ConstDef::decode(reader).for_field("DefinitionDescriptor", "const_def")?,
+          )
+        }
+        14 => {
+          msg.decorator_def = option::Option::Some(
+            DecoratorDef::decode(reader).for_field("DefinitionDescriptor", "decorator_def")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "DefinitionDescriptor",
@@ -3165,15 +3500,39 @@ impl<'buf> bebop::BebopDecode<'buf> for Location<'buf> {
         break;
       }
       match tag {
-        1 => msg.path = option::Option::Some(reader.read_scalar_array::<i32>()?),
-        2 => msg.span = option::Option::Some(reader.read_fixed_array::<i32, 4>()?),
-        3 => msg.leading_comments = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
+        1 => {
+          msg.path = option::Option::Some(
+            reader
+              .read_scalar_array::<i32>()
+              .for_field("Location", "path")?,
+          )
+        }
+        2 => {
+          msg.span = option::Option::Some(
+            reader
+              .read_fixed_array::<i32, 4>()
+              .for_field("Location", "span")?,
+          )
+        }
+        3 => {
+          msg.leading_comments = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("Location", "leading_comments")?,
+          ))
+        }
         4 => {
-          msg.trailing_comments = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?))
+          msg.trailing_comments = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("Location", "trailing_comments")?,
+          ))
         }
         5 => {
           msg.detached_comments = option::Option::Some(
-            reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))?,
+            reader
+              .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
+              .for_field("Location", "detached_comments")?,
           )
         }
         tag => {
@@ -3285,7 +3644,13 @@ impl<'buf> bebop::BebopDecode<'buf> for SourceCodeInfo<'buf> {
         break;
       }
       match tag {
-        1 => msg.locations = option::Option::Some(reader.read_array(|_r| Location::decode(_r))?),
+        1 => {
+          msg.locations = option::Option::Some(
+            reader
+              .read_array(|_r| Location::decode(_r))
+              .for_field("SourceCodeInfo", "locations")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "SourceCodeInfo",
@@ -3426,19 +3791,39 @@ impl<'buf> bebop::BebopDecode<'buf> for SchemaDescriptor<'buf> {
         break;
       }
       match tag {
-        1 => msg.path = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.package = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.edition = option::Option::Some(Edition::decode(reader)?),
+        1 => {
+          msg.path = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("SchemaDescriptor", "path")?,
+          ))
+        }
+        2 => {
+          msg.package = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("SchemaDescriptor", "package")?,
+          ))
+        }
+        3 => {
+          msg.edition =
+            option::Option::Some(Edition::decode(reader).for_field("SchemaDescriptor", "edition")?)
+        }
         4 => {
           msg.imports = option::Option::Some(
-            reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))?,
+            reader
+              .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
+              .for_field("SchemaDescriptor", "imports")?,
           )
         }
         5 => {
-          msg.definitions =
-            option::Option::Some(reader.read_array(|_r| DefinitionDescriptor::decode(_r))?)
+          msg.definitions = option::Option::Some(
+            reader
+              .read_array(|_r| DefinitionDescriptor::decode(_r))
+              .for_field("SchemaDescriptor", "definitions")?,
+          )
         }
-        6 => msg.source_code_info = option::Option::Some(SourceCodeInfo::decode(reader)?),
+        6 => {
+          msg.source_code_info = option::Option::Some(
+            SourceCodeInfo::decode(reader).for_field("SchemaDescriptor", "source_code_info")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "SchemaDescriptor",
@@ -3551,7 +3936,11 @@ impl<'buf> bebop::BebopDecode<'buf> for DescriptorSet<'buf> {
       }
       match tag {
         1 => {
-          msg.schemas = option::Option::Some(reader.read_array(|_r| SchemaDescriptor::decode(_r))?)
+          msg.schemas = option::Option::Some(
+            reader
+              .read_array(|_r| SchemaDescriptor::decode(_r))
+              .for_field("DescriptorSet", "schemas")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {

--- a/plugins/rust/src/generated/plugin.rs
+++ b/plugins/rust/src/generated/plugin.rs
@@ -15,13 +15,13 @@
 extern crate alloc;
 extern crate bebop_runtime;
 extern crate core;
-use super::descriptor::*;
 use alloc::{borrow, boxed, string, vec};
 use bebop_runtime as bebop;
 use bebop_runtime::DecodeContext as _;
 use core::convert::Into as _;
 use core::iter::{IntoIterator as _, Iterator as _};
 use core::{convert, default, iter, mem, ops, option, result};
+use super::descriptor::*;
 
 // @@bebop_insertion_point(imports)
 
@@ -33,7 +33,7 @@ pub struct Version<'buf> {
   pub major: i32,
   pub minor: i32,
   pub patch: i32,
-  /// Pre-release suffix (`alpha.1`, `rc.2`). Empty for stable releases.
+/// Pre-release suffix (`alpha.1`, `rc.2`). Empty for stable releases.
   pub suffix: borrow::Cow<'buf, str>,
 }
 
@@ -47,12 +47,7 @@ impl<'buf> Version<'buf> {
     suffix: impl convert::Into<borrow::Cow<'buf, str>>,
   ) -> Self {
     let suffix = suffix.into();
-    Self {
-      major,
-      minor,
-      patch,
-      suffix,
-    }
+    Self { major, minor, patch, suffix }
   }
 }
 
@@ -96,12 +91,7 @@ impl<'buf> bebop::BebopDecode<'buf> for Version<'buf> {
     let patch = reader.read_i32().for_field("Version", "patch")?;
     let suffix = borrow::Cow::Borrowed(reader.read_str().for_field("Version", "suffix")?);
     // @@bebop_insertion_point(decode_end:Version)
-    result::Result::Ok(Version {
-      major,
-      minor,
-      patch,
-      suffix,
-    })
+    result::Result::Ok(Version { major, minor, patch, suffix })
   }
 }
 
@@ -115,23 +105,23 @@ impl<'buf> Version<'buf> {
 /// `schemas` array for type resolution.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CodeGeneratorRequest<'buf> {
-  /// The .bop files to generate code for (explicitly listed on command line).
-  /// Each file's descriptor is included in `schemas`.
+/// The .bop files to generate code for (explicitly listed on command line).
+/// Each file's descriptor is included in `schemas`.
   pub files_to_generate: option::Option<vec::Vec<borrow::Cow<'buf, str>>>,
-  /// Generator-specific parameter from `--${NAME}_opt=PARAM` or embedded
-  /// in the output path. Format is plugin-defined (commonly key=value pairs).
+/// Generator-specific parameter from `--${NAME}_opt=PARAM` or embedded
+/// in the output path. Format is plugin-defined (commonly key=value pairs).
   pub parameter: option::Option<borrow::Cow<'buf, str>>,
-  /// Version of the compiler invoking the plugin. Use to detect
-  /// incompatibilities or enable version-specific behavior.
+/// Version of the compiler invoking the plugin. Use to detect
+/// incompatibilities or enable version-specific behavior.
   pub compiler_version: option::Option<Version<'buf>>,
-  /// SchemaDescriptors for all files in `files_to_generate` plus their
-  /// imports. Schemas appear in topological order: dependencies before
-  /// dependents. Type FQNs are fully resolved.
-  /// Iterate schemas, check if `schema.path` is in `files_to_generate`,
-  /// and generate code only for those files. The rest are for type resolution.
+/// SchemaDescriptors for all files in `files_to_generate` plus their
+/// imports. Schemas appear in topological order: dependencies before
+/// dependents. Type FQNs are fully resolved.
+/// Iterate schemas, check if `schema.path` is in `files_to_generate`,
+/// and generate code only for those files. The rest are for type resolution.
   pub schemas: option::Option<vec::Vec<SchemaDescriptor<'buf>>>,
-  /// Host compiler options passed to bebopc. Use to adjust output based
-  /// on global settings.
+/// Host compiler options passed to bebopc. Use to adjust output based
+/// on global settings.
   pub host_options: option::Option<bebop::HashMap<borrow::Cow<'buf, str>, borrow::Cow<'buf, str>>>,
 }
 
@@ -140,26 +130,11 @@ pub type CodeGeneratorRequestOwned = CodeGeneratorRequest<'static>;
 impl<'buf> CodeGeneratorRequest<'buf> {
   pub fn into_owned(self) -> CodeGeneratorRequestOwned {
     CodeGeneratorRequest {
-      files_to_generate: self.files_to_generate.map(|v| {
-        v.into_iter()
-          .map(|_e| borrow::Cow::Owned(_e.into_owned()))
-          .collect()
-      }),
+      files_to_generate: self.files_to_generate.map(|v| v.into_iter().map(|_e| borrow::Cow::Owned(_e.into_owned())).collect()),
       parameter: self.parameter.map(|v| borrow::Cow::Owned(v.into_owned())),
       compiler_version: self.compiler_version.map(|v| v.into_owned()),
-      schemas: self
-        .schemas
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
-      host_options: self.host_options.map(|v| {
-        v.into_iter()
-          .map(|(_k, _v)| {
-            (
-              borrow::Cow::Owned(_k.into_owned()),
-              borrow::Cow::Owned(_v.into_owned()),
-            )
-          })
-          .collect()
-      }),
+      schemas: self.schemas.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      host_options: self.host_options.map(|v| v.into_iter().map(|(_k, _v)| (borrow::Cow::Owned(_k.into_owned()), borrow::Cow::Owned(_v.into_owned()))).collect()),
     }
   }
 }
@@ -191,10 +166,7 @@ impl<'buf> bebop::BebopEncode for CodeGeneratorRequest<'buf> {
     }
     if let option::Option::Some(ref v) = self.host_options {
       writer.write_tag(5);
-      writer.write_map(&v, |_w, _k, _v| {
-        _w.write_string(&_k);
-        _w.write_string(&_v);
-      });
+      writer.write_map(&v, |_w, _k, _v| { _w.write_string(&_k); _w.write_string(&_v); });
     }
     writer.write_end_marker();
     writer.fill_message_length(pos);
@@ -204,9 +176,7 @@ impl<'buf> bebop::BebopEncode for CodeGeneratorRequest<'buf> {
   fn encoded_size(&self) -> usize {
     let mut size = bebop::wire_size::WIRE_MESSAGE_BASE_SIZE;
     if let option::Option::Some(ref v) = self.files_to_generate {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| {
-        bebop::wire_size::string_size(_el.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| bebop::wire_size::string_size(_el.len())));
     }
     if let option::Option::Some(ref v) = self.parameter {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
@@ -215,13 +185,10 @@ impl<'buf> bebop::BebopEncode for CodeGeneratorRequest<'buf> {
       size += bebop::wire_size::tagged_size(v.encoded_size());
     }
     if let option::Option::Some(ref v) = self.schemas {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.host_options {
-      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| {
-        bebop::wire_size::string_size(_k.len()) + bebop::wire_size::string_size(_v.len())
-      }));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::map_size(v, |_k, _v| bebop::wire_size::string_size(_k.len()) + bebop::wire_size::string_size(_v.len())));
     }
     size
   }
@@ -237,54 +204,14 @@ impl<'buf> bebop::BebopDecode<'buf> for CodeGeneratorRequest<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.files_to_generate = option::Option::Some(
-            reader
-              .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
-              .for_field("CodeGeneratorRequest", "files_to_generate")?,
-          )
-        }
-        2 => {
-          msg.parameter = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("CodeGeneratorRequest", "parameter")?,
-          ))
-        }
-        3 => {
-          msg.compiler_version = option::Option::Some(
-            Version::decode(reader).for_field("CodeGeneratorRequest", "compiler_version")?,
-          )
-        }
-        4 => {
-          msg.schemas = option::Option::Some(
-            reader
-              .read_array(|_r| SchemaDescriptor::decode(_r))
-              .for_field("CodeGeneratorRequest", "schemas")?,
-          )
-        }
-        5 => {
-          msg.host_options = option::Option::Some(
-            reader
-              .read_map(|_r| {
-                result::Result::Ok((
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-                ))
-              })
-              .for_field("CodeGeneratorRequest", "host_options")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "CodeGeneratorRequest",
-            tag,
-          });
-        }
+        1 => msg.files_to_generate = option::Option::Some(reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))).for_field("CodeGeneratorRequest", "files_to_generate")?),
+        2 => msg.parameter = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("CodeGeneratorRequest", "parameter")?)),
+        3 => msg.compiler_version = option::Option::Some(Version::decode(reader).for_field("CodeGeneratorRequest", "compiler_version")?),
+        4 => msg.schemas = option::Option::Some(reader.read_array(|_r| SchemaDescriptor::decode(_r)).for_field("CodeGeneratorRequest", "schemas")?),
+        5 => msg.host_options = option::Option::Some(reader.read_map(|_r| result::Result::Ok((result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?, result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?))).for_field("CodeGeneratorRequest", "host_options")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "CodeGeneratorRequest", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:CodeGeneratorRequest)
@@ -293,10 +220,7 @@ impl<'buf> bebop::BebopDecode<'buf> for CodeGeneratorRequest<'buf> {
 }
 
 impl<'buf> CodeGeneratorRequest<'buf> {
-  pub fn with_files_to_generate(
-    mut self,
-    value: impl iter::IntoIterator<Item = impl convert::Into<borrow::Cow<'buf, str>>>,
-  ) -> Self {
+  pub fn with_files_to_generate(mut self, value: impl iter::IntoIterator<Item = impl convert::Into<borrow::Cow<'buf, str>>>) -> Self {
     self.files_to_generate = option::Option::Some(value.into_iter().map(|_e| _e.into()).collect());
     self
   }
@@ -308,28 +232,12 @@ impl<'buf> CodeGeneratorRequest<'buf> {
     self.compiler_version = option::Option::Some(value);
     self
   }
-  pub fn with_schemas(
-    mut self,
-    value: impl iter::IntoIterator<Item = SchemaDescriptor<'buf>>,
-  ) -> Self {
+  pub fn with_schemas(mut self, value: impl iter::IntoIterator<Item = SchemaDescriptor<'buf>>) -> Self {
     self.schemas = option::Option::Some(value.into_iter().collect());
     self
   }
-  pub fn with_host_options(
-    mut self,
-    value: impl iter::IntoIterator<
-      Item = (
-        impl convert::Into<borrow::Cow<'buf, str>>,
-        impl convert::Into<borrow::Cow<'buf, str>>,
-      ),
-    >,
-  ) -> Self {
-    self.host_options = option::Option::Some(
-      value
-        .into_iter()
-        .map(|(_k, _v)| (_k.into(), _v.into()))
-        .collect(),
-    );
+  pub fn with_host_options(mut self, value: impl iter::IntoIterator<Item = (impl convert::Into<borrow::Cow<'buf, str>>, impl convert::Into<borrow::Cow<'buf, str>>)>) -> Self {
+    self.host_options = option::Option::Some(value.into_iter().map(|(_k, _v)| (_k.into(), _v.into())).collect());
     self
   }
   // @@bebop_insertion_point(message_scope:CodeGeneratorRequest)
@@ -353,18 +261,13 @@ impl convert::TryFrom<u8> for DiagnosticSeverity {
       1 => result::Result::Ok(Self::Warning),
       2 => result::Result::Ok(Self::Info),
       3 => result::Result::Ok(Self::Hint),
-      _ => result::Result::Err(bebop::DecodeError::InvalidEnum {
-        type_name: "DiagnosticSeverity",
-        value: value as u64,
-      }),
+      _ => result::Result::Err(bebop::DecodeError::InvalidEnum { type_name: "DiagnosticSeverity", value: value as u64 }),
     }
   }
 }
 
 impl convert::From<DiagnosticSeverity> for u8 {
-  fn from(value: DiagnosticSeverity) -> u8 {
-    value as u8
-  }
+  fn from(value: DiagnosticSeverity) -> u8 { value as u8 }
 }
 
 impl DiagnosticSeverity {
@@ -379,9 +282,7 @@ impl bebop::BebopEncode for DiagnosticSeverity {
     // @@bebop_insertion_point(encode_end:DiagnosticSeverity)
   }
 
-  fn encoded_size(&self) -> usize {
-    Self::FIXED_ENCODED_SIZE
-  }
+  fn encoded_size(&self) -> usize { Self::FIXED_ENCODED_SIZE }
 }
 
 impl<'buf> bebop::BebopDecode<'buf> for DiagnosticSeverity {
@@ -400,14 +301,14 @@ impl<'buf> bebop::BebopDecode<'buf> for DiagnosticSeverity {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct Diagnostic<'buf> {
   pub severity: option::Option<DiagnosticSeverity>,
-  /// Human-readable diagnostic text.
+/// Human-readable diagnostic text.
   pub text: option::Option<borrow::Cow<'buf, str>>,
-  /// Optional hint for fixing the issue.
+/// Optional hint for fixing the issue.
   pub hint: option::Option<borrow::Cow<'buf, str>>,
-  /// Source file path this diagnostic relates to.
+/// Source file path this diagnostic relates to.
   pub file: option::Option<borrow::Cow<'buf, str>>,
-  /// Source location as `[start_line, start_col, end_line, end_col]`.
-  /// 1-based. Absent if not applicable.
+/// Source location as `[start_line, start_col, end_line, end_col]`.
+/// 1-based. Absent if not applicable.
   pub span: option::Option<[i32; 4]>,
 }
 
@@ -490,43 +391,14 @@ impl<'buf> bebop::BebopDecode<'buf> for Diagnostic<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.severity = option::Option::Some(
-            DiagnosticSeverity::decode(reader).for_field("Diagnostic", "severity")?,
-          )
-        }
-        2 => {
-          msg.text = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("Diagnostic", "text")?,
-          ))
-        }
-        3 => {
-          msg.hint = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("Diagnostic", "hint")?,
-          ))
-        }
-        4 => {
-          msg.file = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("Diagnostic", "file")?,
-          ))
-        }
-        5 => {
-          msg.span = option::Option::Some(
-            reader
-              .read_fixed_array::<i32, 4>()
-              .for_field("Diagnostic", "span")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "Diagnostic",
-            tag,
-          });
-        }
+        1 => msg.severity = option::Option::Some(DiagnosticSeverity::decode(reader).for_field("Diagnostic", "severity")?),
+        2 => msg.text = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Diagnostic", "text")?)),
+        3 => msg.hint = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Diagnostic", "hint")?)),
+        4 => msg.file = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("Diagnostic", "file")?)),
+        5 => msg.span = option::Option::Some(reader.read_fixed_array::<i32, 4>().for_field("Diagnostic", "span")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "Diagnostic", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:Diagnostic)
@@ -563,27 +435,27 @@ impl<'buf> Diagnostic<'buf> {
 /// marked insertion point.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct GeneratedFile<'buf> {
-  /// Output path relative to output directory. No `..` components or
-  /// leading `/`. Use `/` as separator on all platforms.
-  /// When `insertion_point` is set, names the file to insert into (must
-  /// be generated by a prior plugin in the same invocation).
-  /// When omitted, content appends to the previous file. Allows generators
-  /// to stream large files in chunks.
+/// Output path relative to output directory. No `..` components or
+/// leading `/`. Use `/` as separator on all platforms.
+/// When `insertion_point` is set, names the file to insert into (must
+/// be generated by a prior plugin in the same invocation).
+/// When omitted, content appends to the previous file. Allows generators
+/// to stream large files in chunks.
   pub name: option::Option<borrow::Cow<'buf, str>>,
-  /// Insertion point name for extending another plugin's output.
-  /// Target file must contain:
-  /// ```
-  /// // @@bebopc_insertion_point(NAME)
-  /// ```
-  /// Content inserts above this marker. Multiple insertions to the same
-  /// point appear in plugin execution order.
-  /// When set, `name` must also be set to identify the target file.
+/// Insertion point name for extending another plugin's output.
+/// Target file must contain:
+/// ```
+/// // @@bebopc_insertion_point(NAME)
+/// ```
+/// Content inserts above this marker. Multiple insertions to the same
+/// point appear in plugin execution order.
+/// When set, `name` must also be set to identify the target file.
   pub insertion_point: option::Option<borrow::Cow<'buf, str>>,
-  /// File contents (complete file or insertion fragment).
-  /// For insertions, typically includes a trailing newline.
+/// File contents (complete file or insertion fragment).
+/// For insertions, typically includes a trailing newline.
   pub content: option::Option<borrow::Cow<'buf, str>>,
-  /// Source mapping connecting generated code to source schemas.
-  /// Optional; enables IDE features like go-to-definition.
+/// Source mapping connecting generated code to source schemas.
+/// Optional; enables IDE features like go-to-definition.
   pub generated_code_info: option::Option<SourceCodeInfo<'buf>>,
 }
 
@@ -593,9 +465,7 @@ impl<'buf> GeneratedFile<'buf> {
   pub fn into_owned(self) -> GeneratedFileOwned {
     GeneratedFile {
       name: self.name.map(|v| borrow::Cow::Owned(v.into_owned())),
-      insertion_point: self
-        .insertion_point
-        .map(|v| borrow::Cow::Owned(v.into_owned())),
+      insertion_point: self.insertion_point.map(|v| borrow::Cow::Owned(v.into_owned())),
       content: self.content.map(|v| borrow::Cow::Owned(v.into_owned())),
       generated_code_info: self.generated_code_info.map(|v| v.into_owned()),
     }
@@ -660,38 +530,13 @@ impl<'buf> bebop::BebopDecode<'buf> for GeneratedFile<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.name = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("GeneratedFile", "name")?,
-          ))
-        }
-        2 => {
-          msg.insertion_point = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("GeneratedFile", "insertion_point")?,
-          ))
-        }
-        3 => {
-          msg.content = option::Option::Some(borrow::Cow::Borrowed(
-            reader.read_str().for_field("GeneratedFile", "content")?,
-          ))
-        }
-        4 => {
-          msg.generated_code_info = option::Option::Some(
-            SourceCodeInfo::decode(reader).for_field("GeneratedFile", "generated_code_info")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "GeneratedFile",
-            tag,
-          });
-        }
+        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("GeneratedFile", "name")?)),
+        2 => msg.insertion_point = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("GeneratedFile", "insertion_point")?)),
+        3 => msg.content = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("GeneratedFile", "content")?)),
+        4 => msg.generated_code_info = option::Option::Some(SourceCodeInfo::decode(reader).for_field("GeneratedFile", "generated_code_info")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "GeneratedFile", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:GeneratedFile)
@@ -731,17 +576,17 @@ impl<'buf> GeneratedFile<'buf> {
 /// that prevent correct code generation.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct CodeGeneratorResponse<'buf> {
-  /// Error message. If non-empty, code generation failed.
-  /// Set for schema problems that prevent generating correct code. Exit
-  /// with status zero.
-  /// For plugin bugs or environment problems (can't read input, out of
-  /// memory), write to stderr and exit non-zero instead.
+/// Error message. If non-empty, code generation failed.
+/// Set for schema problems that prevent generating correct code. Exit
+/// with status zero.
+/// For plugin bugs or environment problems (can't read input, out of
+/// memory), write to stderr and exit non-zero instead.
   pub error: option::Option<borrow::Cow<'buf, str>>,
-  /// Generated files to write to the output directory.
-  /// Written in array order. Later files with `insertion_point` can
-  /// extend earlier files in the same response.
+/// Generated files to write to the output directory.
+/// Written in array order. Later files with `insertion_point` can
+/// extend earlier files in the same response.
   pub files: option::Option<vec::Vec<GeneratedFile<'buf>>>,
-  /// Diagnostics to report. Displayed even on success (for warnings/info).
+/// Diagnostics to report. Displayed even on success (for warnings/info).
   pub diagnostics: option::Option<vec::Vec<Diagnostic<'buf>>>,
 }
 
@@ -751,12 +596,8 @@ impl<'buf> CodeGeneratorResponse<'buf> {
   pub fn into_owned(self) -> CodeGeneratorResponseOwned {
     CodeGeneratorResponse {
       error: self.error.map(|v| borrow::Cow::Owned(v.into_owned())),
-      files: self
-        .files
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
-      diagnostics: self
-        .diagnostics
-        .map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      files: self.files.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
+      diagnostics: self.diagnostics.map(|v| v.into_iter().map(|_e| _e.into_owned()).collect()),
     }
   }
 }
@@ -793,12 +634,10 @@ impl<'buf> bebop::BebopEncode for CodeGeneratorResponse<'buf> {
       size += bebop::wire_size::tagged_size(bebop::wire_size::string_size(v.len()));
     }
     if let option::Option::Some(ref v) = self.files {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     if let option::Option::Some(ref v) = self.diagnostics {
-      size +=
-        bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
+      size += bebop::wire_size::tagged_size(bebop::wire_size::array_size(v, |_el| _el.encoded_size()));
     }
     size
   }
@@ -814,37 +653,12 @@ impl<'buf> bebop::BebopDecode<'buf> for CodeGeneratorResponse<'buf> {
 
     while reader.position() < end {
       let tag = reader.read_tag()?;
-      if tag == 0 {
-        break;
-      }
+      if tag == 0 { break; }
       match tag {
-        1 => {
-          msg.error = option::Option::Some(borrow::Cow::Borrowed(
-            reader
-              .read_str()
-              .for_field("CodeGeneratorResponse", "error")?,
-          ))
-        }
-        2 => {
-          msg.files = option::Option::Some(
-            reader
-              .read_array(|_r| GeneratedFile::decode(_r))
-              .for_field("CodeGeneratorResponse", "files")?,
-          )
-        }
-        3 => {
-          msg.diagnostics = option::Option::Some(
-            reader
-              .read_array(|_r| Diagnostic::decode(_r))
-              .for_field("CodeGeneratorResponse", "diagnostics")?,
-          )
-        }
-        tag => {
-          return result::Result::Err(bebop::DecodeError::InvalidField {
-            type_name: "CodeGeneratorResponse",
-            tag,
-          });
-        }
+        1 => msg.error = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field("CodeGeneratorResponse", "error")?)),
+        2 => msg.files = option::Option::Some(reader.read_array(|_r| GeneratedFile::decode(_r)).for_field("CodeGeneratorResponse", "files")?),
+        3 => msg.diagnostics = option::Option::Some(reader.read_array(|_r| Diagnostic::decode(_r)).for_field("CodeGeneratorResponse", "diagnostics")?),
+        tag => { return result::Result::Err(bebop::DecodeError::InvalidField { type_name: "CodeGeneratorResponse", tag }); }
       }
     }
     // @@bebop_insertion_point(decode_end:CodeGeneratorResponse)
@@ -861,10 +675,7 @@ impl<'buf> CodeGeneratorResponse<'buf> {
     self.files = option::Option::Some(value.into_iter().collect());
     self
   }
-  pub fn with_diagnostics(
-    mut self,
-    value: impl iter::IntoIterator<Item = Diagnostic<'buf>>,
-  ) -> Self {
+  pub fn with_diagnostics(mut self, value: impl iter::IntoIterator<Item = Diagnostic<'buf>>) -> Self {
     self.diagnostics = option::Option::Some(value.into_iter().collect());
     self
   }

--- a/plugins/rust/src/generated/plugin.rs
+++ b/plugins/rust/src/generated/plugin.rs
@@ -18,6 +18,7 @@ extern crate core;
 use super::descriptor::*;
 use alloc::{borrow, boxed, string, vec};
 use bebop_runtime as bebop;
+use bebop_runtime::DecodeContext as _;
 use core::convert::Into as _;
 use core::iter::{IntoIterator as _, Iterator as _};
 use core::{convert, default, iter, mem, ops, option, result};
@@ -90,10 +91,10 @@ impl<'buf> bebop::BebopDecode<'buf> for Version<'buf> {
   #[inline]
   fn decode(reader: &mut bebop::BebopReader<'buf>) -> result::Result<Self, bebop::DecodeError> {
     // @@bebop_insertion_point(decode_start:Version)
-    let major = reader.read_i32()?;
-    let minor = reader.read_i32()?;
-    let patch = reader.read_i32()?;
-    let suffix = borrow::Cow::Borrowed(reader.read_str()?);
+    let major = reader.read_i32().for_field("Version", "major")?;
+    let minor = reader.read_i32().for_field("Version", "minor")?;
+    let patch = reader.read_i32().for_field("Version", "patch")?;
+    let suffix = borrow::Cow::Borrowed(reader.read_str().for_field("Version", "suffix")?);
     // @@bebop_insertion_point(decode_end:Version)
     result::Result::Ok(Version {
       major,
@@ -242,21 +243,41 @@ impl<'buf> bebop::BebopDecode<'buf> for CodeGeneratorRequest<'buf> {
       match tag {
         1 => {
           msg.files_to_generate = option::Option::Some(
-            reader.read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))?,
+            reader
+              .read_array(|_r| result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?)))
+              .for_field("CodeGeneratorRequest", "files_to_generate")?,
           )
         }
-        2 => msg.parameter = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.compiler_version = option::Option::Some(Version::decode(reader)?),
+        2 => {
+          msg.parameter = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("CodeGeneratorRequest", "parameter")?,
+          ))
+        }
+        3 => {
+          msg.compiler_version = option::Option::Some(
+            Version::decode(reader).for_field("CodeGeneratorRequest", "compiler_version")?,
+          )
+        }
         4 => {
-          msg.schemas = option::Option::Some(reader.read_array(|_r| SchemaDescriptor::decode(_r))?)
+          msg.schemas = option::Option::Some(
+            reader
+              .read_array(|_r| SchemaDescriptor::decode(_r))
+              .for_field("CodeGeneratorRequest", "schemas")?,
+          )
         }
         5 => {
-          msg.host_options = option::Option::Some(reader.read_map(|_r| {
-            result::Result::Ok((
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-              result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
-            ))
-          })?)
+          msg.host_options = option::Option::Some(
+            reader
+              .read_map(|_r| {
+                result::Result::Ok((
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                  result::Result::Ok(borrow::Cow::Borrowed(_r.read_str()?))?,
+                ))
+              })
+              .for_field("CodeGeneratorRequest", "host_options")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
@@ -473,11 +494,33 @@ impl<'buf> bebop::BebopDecode<'buf> for Diagnostic<'buf> {
         break;
       }
       match tag {
-        1 => msg.severity = option::Option::Some(DiagnosticSeverity::decode(reader)?),
-        2 => msg.text = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.hint = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        4 => msg.file = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        5 => msg.span = option::Option::Some(reader.read_fixed_array::<i32, 4>()?),
+        1 => {
+          msg.severity = option::Option::Some(
+            DiagnosticSeverity::decode(reader).for_field("Diagnostic", "severity")?,
+          )
+        }
+        2 => {
+          msg.text = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("Diagnostic", "text")?,
+          ))
+        }
+        3 => {
+          msg.hint = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("Diagnostic", "hint")?,
+          ))
+        }
+        4 => {
+          msg.file = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("Diagnostic", "file")?,
+          ))
+        }
+        5 => {
+          msg.span = option::Option::Some(
+            reader
+              .read_fixed_array::<i32, 4>()
+              .for_field("Diagnostic", "span")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "Diagnostic",
@@ -621,10 +664,28 @@ impl<'buf> bebop::BebopDecode<'buf> for GeneratedFile<'buf> {
         break;
       }
       match tag {
-        1 => msg.name = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.insertion_point = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        3 => msg.content = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        4 => msg.generated_code_info = option::Option::Some(SourceCodeInfo::decode(reader)?),
+        1 => {
+          msg.name = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("GeneratedFile", "name")?,
+          ))
+        }
+        2 => {
+          msg.insertion_point = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("GeneratedFile", "insertion_point")?,
+          ))
+        }
+        3 => {
+          msg.content = option::Option::Some(borrow::Cow::Borrowed(
+            reader.read_str().for_field("GeneratedFile", "content")?,
+          ))
+        }
+        4 => {
+          msg.generated_code_info = option::Option::Some(
+            SourceCodeInfo::decode(reader).for_field("GeneratedFile", "generated_code_info")?,
+          )
+        }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {
             type_name: "GeneratedFile",
@@ -757,10 +818,26 @@ impl<'buf> bebop::BebopDecode<'buf> for CodeGeneratorResponse<'buf> {
         break;
       }
       match tag {
-        1 => msg.error = option::Option::Some(borrow::Cow::Borrowed(reader.read_str()?)),
-        2 => msg.files = option::Option::Some(reader.read_array(|_r| GeneratedFile::decode(_r))?),
+        1 => {
+          msg.error = option::Option::Some(borrow::Cow::Borrowed(
+            reader
+              .read_str()
+              .for_field("CodeGeneratorResponse", "error")?,
+          ))
+        }
+        2 => {
+          msg.files = option::Option::Some(
+            reader
+              .read_array(|_r| GeneratedFile::decode(_r))
+              .for_field("CodeGeneratorResponse", "files")?,
+          )
+        }
         3 => {
-          msg.diagnostics = option::Option::Some(reader.read_array(|_r| Diagnostic::decode(_r))?)
+          msg.diagnostics = option::Option::Some(
+            reader
+              .read_array(|_r| Diagnostic::decode(_r))
+              .for_field("CodeGeneratorResponse", "diagnostics")?,
+          )
         }
         tag => {
           return result::Result::Err(bebop::DecodeError::InvalidField {

--- a/plugins/rust/src/generator/gen_message.rs
+++ b/plugins/rust/src/generator/gen_message.rs
@@ -311,25 +311,35 @@ pub fn generate(
   output.push_str("      match tag {\n");
 
   for meta in &field_metas {
+    let fname_ctx = meta.fname.strip_prefix("r#").unwrap_or(&meta.fname);
+    let kind = meta.td.kind.unwrap_or(TypeKind::Unknown);
     match meta.wrap {
       FieldWrap::Boxed => {
         let read_expr = type_mapper::read_expression(meta.td, "reader", analysis)?;
         output.push_str(&format!(
-          "        {} => msg.{} = option::Option::Some(boxed::Box::new({}?)),\n",
-          meta.tag, meta.fname, read_expr
+          "        {} => msg.{} = option::Option::Some(boxed::Box::new({}.for_field(\"{}\", \"{}\")?)),\n",
+          meta.tag, meta.fname, read_expr, name, fname_ctx
         ));
       }
       _ => {
-        if let Some(read_expr) = type_mapper::borrowed_cow_read_expression(meta.td, "reader") {
+        if kind == TypeKind::String {
+          // Zero-copy string: apply for_field on read_str(), then wrap in Cow.
           output.push_str(&format!(
-            "        {} => msg.{} = option::Option::Some({}),\n",
-            meta.tag, meta.fname, read_expr
+            "        {} => msg.{} = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field(\"{}\", \"{}\")?)),\n",
+            meta.tag, meta.fname, name, fname_ctx
+          ));
+        } else if type_mapper::is_byte_array_cow_field(meta.td) {
+          // Zero-copy byte array: apply for_field on read_byte_slice(), then wrap in BebopBytes.
+          output.push_str(&format!(
+            "        {} => msg.{} = option::Option::Some(bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field(\"{}\", \"{}\")?)),\n",
+            meta.tag, meta.fname, name, fname_ctx
           ));
         } else {
+          // Scalars, defined types, arrays, maps: append for_field before ?.
           let read_expr = type_mapper::read_expression(meta.td, "reader", analysis)?;
           output.push_str(&format!(
-            "        {} => msg.{} = option::Option::Some({}?),\n",
-            meta.tag, meta.fname, read_expr
+            "        {} => msg.{} = option::Option::Some({}.for_field(\"{}\", \"{}\")?),\n",
+            meta.tag, meta.fname, read_expr, name, fname_ctx
           ));
         }
       }

--- a/plugins/rust/src/generator/gen_message.rs
+++ b/plugins/rust/src/generator/gen_message.rs
@@ -123,8 +123,7 @@ pub fn generate(
       // - RAW_REJECTED fields (e.g. `self`) are suffix-mangled to `self_`; use serde rename.
       // - Keyword fields (e.g. `type`) are prefixed with `r#`; strip the prefix.
       // - Regular fields are unchanged.
-      let schema_name = serde_field_rename(raw)
-        .unwrap_or_else(|| fname.strip_prefix("r#").unwrap_or(&fname).to_string());
+      let schema_name = raw.to_string();
       let td = f
         .r#type
         .as_ref()

--- a/plugins/rust/src/generator/gen_message.rs
+++ b/plugins/rust/src/generator/gen_message.rs
@@ -316,37 +316,20 @@ pub fn generate(
   output.push_str("      match tag {\n");
 
   for meta in &field_metas {
-    let fname_ctx = &meta.schema_name;
-    let kind = meta.td.kind.unwrap_or(TypeKind::Unknown);
+    let expr =
+      type_mapper::read_field_expression(meta.td, "reader", analysis, &name, &meta.schema_name)?;
     match meta.wrap {
       FieldWrap::Boxed => {
-        let read_expr = type_mapper::read_expression(meta.td, "reader", analysis)?;
         output.push_str(&format!(
-          "        {} => msg.{} = option::Option::Some(boxed::Box::new({}.for_field(\"{}\", \"{}\")?)),\n",
-          meta.tag, meta.fname, read_expr, name, fname_ctx
+          "        {} => msg.{} = option::Option::Some(boxed::Box::new({})),\n",
+          meta.tag, meta.fname, expr
         ));
       }
       _ => {
-        if kind == TypeKind::String {
-          // Zero-copy string: apply for_field on read_str(), then wrap in Cow.
-          output.push_str(&format!(
-            "        {} => msg.{} = option::Option::Some(borrow::Cow::Borrowed(reader.read_str().for_field(\"{}\", \"{}\")?)),\n",
-            meta.tag, meta.fname, name, fname_ctx
-          ));
-        } else if type_mapper::is_byte_array_cow_field(meta.td) {
-          // Zero-copy byte array: apply for_field on read_byte_slice(), then wrap in BebopBytes.
-          output.push_str(&format!(
-            "        {} => msg.{} = option::Option::Some(bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field(\"{}\", \"{}\")?)),\n",
-            meta.tag, meta.fname, name, fname_ctx
-          ));
-        } else {
-          // Scalars, defined types, arrays, maps: append for_field before ?.
-          let read_expr = type_mapper::read_expression(meta.td, "reader", analysis)?;
-          output.push_str(&format!(
-            "        {} => msg.{} = option::Option::Some({}.for_field(\"{}\", \"{}\")?),\n",
-            meta.tag, meta.fname, read_expr, name, fname_ctx
-          ));
-        }
+        output.push_str(&format!(
+          "        {} => msg.{} = option::Option::Some({}),\n",
+          meta.tag, meta.fname, expr
+        ));
       }
     }
   }

--- a/plugins/rust/src/generator/gen_message.rs
+++ b/plugins/rust/src/generator/gen_message.rs
@@ -42,6 +42,8 @@ fn field_wrap(field_type: &TypeDescriptor<'_>, own_fqn: &str) -> FieldWrap {
 /// Pre-computed metadata for a single message field.
 struct FieldMeta<'a> {
   fname: String,
+  /// Bebop schema field name for decode error context (e.g. `"self"`, not `"self_"`).
+  schema_name: String,
   cow_type: String,
   tag: u32,
   wrap: FieldWrap,
@@ -115,7 +117,14 @@ pub fn generate(
   let field_metas: Vec<FieldMeta<'_>> = fields
     .iter()
     .map(|f| {
-      let fname = field_name(f.name.as_deref().unwrap_or("unknown"));
+      let raw = f.name.as_deref().unwrap_or("unknown");
+      let fname = field_name(raw);
+      // Recover the Bebop schema name for decode error context:
+      // - RAW_REJECTED fields (e.g. `self`) are suffix-mangled to `self_`; use serde rename.
+      // - Keyword fields (e.g. `type`) are prefixed with `r#`; strip the prefix.
+      // - Regular fields are unchanged.
+      let schema_name = serde_field_rename(raw)
+        .unwrap_or_else(|| fname.strip_prefix("r#").unwrap_or(&fname).to_string());
       let td = f
         .r#type
         .as_ref()
@@ -127,6 +136,7 @@ pub fn generate(
       let wrap = field_wrap(td, own_fqn);
       Ok(FieldMeta {
         fname,
+        schema_name,
         cow_type,
         tag,
         wrap,
@@ -311,7 +321,7 @@ pub fn generate(
   output.push_str("      match tag {\n");
 
   for meta in &field_metas {
-    let fname_ctx = meta.fname.strip_prefix("r#").unwrap_or(&meta.fname);
+    let fname_ctx = &meta.schema_name;
     let kind = meta.td.kind.unwrap_or(TypeKind::Unknown);
     match meta.wrap {
       FieldWrap::Boxed => {

--- a/plugins/rust/src/generator/gen_message.rs
+++ b/plugins/rust/src/generator/gen_message.rs
@@ -119,10 +119,6 @@ pub fn generate(
     .map(|f| {
       let raw = f.name.as_deref().unwrap_or("unknown");
       let fname = field_name(raw);
-      // Recover the Bebop schema name for decode error context:
-      // - RAW_REJECTED fields (e.g. `self`) are suffix-mangled to `self_`; use serde rename.
-      // - Keyword fields (e.g. `type`) are prefixed with `r#`; strip the prefix.
-      // - Regular fields are unchanged.
       let schema_name = raw.to_string();
       let td = f
         .r#type

--- a/plugins/rust/src/generator/gen_struct.rs
+++ b/plugins/rust/src/generator/gen_struct.rs
@@ -9,6 +9,8 @@ use super::{
 
 struct StructFieldMeta<'a> {
   fname: String,
+  /// Bebop schema field name for decode error context (e.g. `"self"`, not `"self_"`).
+  schema_name: String,
   cow_type: String,
   owned_type: String,
   td: &'a TypeDescriptor<'a>,
@@ -48,8 +50,17 @@ pub fn generate(
         .r#type
         .as_ref()
         .ok_or_else(|| GeneratorError::MalformedDefinition("struct field missing type".into()))?;
+      let raw = f.name.as_deref().unwrap_or("unknown");
+      let fname = field_name(raw);
+      // Recover the Bebop schema name for decode error context:
+      // - RAW_REJECTED fields (e.g. `self`) are suffix-mangled to `self_`; use serde rename.
+      // - Keyword fields (e.g. `type`) are prefixed with `r#`; strip the prefix.
+      // - Regular fields are unchanged.
+      let schema_name = serde_field_rename(raw)
+        .unwrap_or_else(|| fname.strip_prefix("r#").unwrap_or(&fname).to_string());
       Ok(StructFieldMeta {
-        fname: field_name(f.name.as_deref().unwrap_or("unknown")),
+        fname,
+        schema_name,
         cow_type: type_mapper::rust_type(td, analysis)?,
         owned_type: type_mapper::rust_type_owned(td, analysis)?,
         td,
@@ -260,7 +271,7 @@ pub fn generate(
     name
   ));
   for meta in &field_metas {
-    let fname_ctx = meta.fname.strip_prefix("r#").unwrap_or(&meta.fname);
+    let fname_ctx = &meta.schema_name;
     let kind = meta.td.kind.unwrap_or(TypeKind::Unknown);
     if kind == TypeKind::String {
       // Zero-copy string: apply for_field on read_str(), then wrap in Cow.

--- a/plugins/rust/src/generator/gen_struct.rs
+++ b/plugins/rust/src/generator/gen_struct.rs
@@ -1,5 +1,5 @@
 use crate::error::GeneratorError;
-use crate::generated::{DefinitionDescriptor, TypeDescriptor, TypeKind};
+use crate::generated::{DefinitionDescriptor, TypeDescriptor};
 
 use super::naming::{field_name, serde_field_rename, type_name};
 use super::type_mapper;
@@ -272,28 +272,9 @@ pub fn generate(
     name
   ));
   for meta in &field_metas {
-    let fname_ctx = &meta.schema_name;
-    let kind = meta.td.kind.unwrap_or(TypeKind::Unknown);
-    if kind == TypeKind::String {
-      // Zero-copy string: apply for_field on read_str(), then wrap in Cow.
-      output.push_str(&format!(
-        "    let {} = borrow::Cow::Borrowed(reader.read_str().for_field(\"{}\", \"{}\")?);\n",
-        meta.fname, name, fname_ctx
-      ));
-    } else if type_mapper::is_byte_array_cow_field(meta.td) {
-      // Zero-copy byte array: apply for_field on read_byte_slice(), then wrap in BebopBytes.
-      output.push_str(&format!(
-        "    let {} = bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field(\"{}\", \"{}\")?);\n",
-        meta.fname, name, fname_ctx
-      ));
-    } else {
-      // Scalars, defined types, arrays, maps: append for_field before ?.
-      let read_expr = type_mapper::read_expression(meta.td, "reader", analysis)?;
-      output.push_str(&format!(
-        "    let {} = {}.for_field(\"{}\", \"{}\")?;\n",
-        meta.fname, read_expr, name, fname_ctx
-      ));
-    }
+    let expr =
+      type_mapper::read_field_expression(meta.td, "reader", analysis, &name, &meta.schema_name)?;
+    output.push_str(&format!("    let {} = {};\n", meta.fname, expr));
   }
   output.push_str(&format!(
     "    // @@bebop_insertion_point(decode_end:{})\n",

--- a/plugins/rust/src/generator/gen_struct.rs
+++ b/plugins/rust/src/generator/gen_struct.rs
@@ -1,5 +1,5 @@
 use crate::error::GeneratorError;
-use crate::generated::{DefinitionDescriptor, TypeDescriptor};
+use crate::generated::{DefinitionDescriptor, TypeDescriptor, TypeKind};
 
 use super::naming::{field_name, serde_field_rename, type_name};
 use super::type_mapper;
@@ -260,11 +260,27 @@ pub fn generate(
     name
   ));
   for meta in &field_metas {
-    if let Some(read_expr) = type_mapper::borrowed_cow_read_expression(meta.td, "reader") {
-      output.push_str(&format!("    let {} = {};\n", meta.fname, read_expr));
+    let fname_ctx = meta.fname.strip_prefix("r#").unwrap_or(&meta.fname);
+    let kind = meta.td.kind.unwrap_or(TypeKind::Unknown);
+    if kind == TypeKind::String {
+      // Zero-copy string: apply for_field on read_str(), then wrap in Cow.
+      output.push_str(&format!(
+        "    let {} = borrow::Cow::Borrowed(reader.read_str().for_field(\"{}\", \"{}\")?);\n",
+        meta.fname, name, fname_ctx
+      ));
+    } else if type_mapper::is_byte_array_cow_field(meta.td) {
+      // Zero-copy byte array: apply for_field on read_byte_slice(), then wrap in BebopBytes.
+      output.push_str(&format!(
+        "    let {} = bebop::BebopBytes::borrowed(reader.read_byte_slice().for_field(\"{}\", \"{}\")?);\n",
+        meta.fname, name, fname_ctx
+      ));
     } else {
+      // Scalars, defined types, arrays, maps: append for_field before ?.
       let read_expr = type_mapper::read_expression(meta.td, "reader", analysis)?;
-      output.push_str(&format!("    let {} = {}?;\n", meta.fname, read_expr));
+      output.push_str(&format!(
+        "    let {} = {}.for_field(\"{}\", \"{}\")?;\n",
+        meta.fname, read_expr, name, fname_ctx
+      ));
     }
   }
   output.push_str(&format!(

--- a/plugins/rust/src/generator/gen_struct.rs
+++ b/plugins/rust/src/generator/gen_struct.rs
@@ -142,30 +142,36 @@ pub fn generate(
       }
     }
   }
-  output.push_str("  pub fn new(");
   // Pre-compute IntoIterator info for collection fields
   let collection_infos: Vec<Option<(String, String)>> = field_metas
     .iter()
     .map(|meta| type_mapper::collection_into_iter(meta.td, &meta.fname, analysis))
     .collect::<Result<Vec<_>, GeneratorError>>()?;
 
-  for (i, meta) in field_metas.iter().enumerate() {
-    if i > 0 {
-      output.push_str(", ");
+  let params: Vec<String> = field_metas
+    .iter()
+    .enumerate()
+    .map(|(i, meta)| {
+      let param_type = if let Some((ref pt, _)) = collection_infos[i] {
+        pt.clone()
+      } else if has_lifetime && type_mapper::is_cow_field(meta.td) {
+        format!("impl convert::Into<{}>", meta.cow_type)
+      } else {
+        meta.owned_type.clone()
+      };
+      format!("{}: {}", meta.fname, param_type)
+    })
+    .collect();
+
+  if params.len() >= 2 {
+    output.push_str("  pub fn new(\n");
+    for p in &params {
+      output.push_str(&format!("    {},\n", p));
     }
-    if let Some((ref param_type, _)) = collection_infos[i] {
-      // Collection field with IntoIterator
-      output.push_str(&format!("{}: {}", meta.fname, param_type));
-    } else if has_lifetime && type_mapper::is_cow_field(meta.td) {
-      output.push_str(&format!(
-        "{}: impl convert::Into<{}>",
-        meta.fname, meta.cow_type
-      ));
-    } else {
-      output.push_str(&format!("{}: {}", meta.fname, meta.owned_type));
-    }
+    output.push_str("  ) -> Self {\n");
+  } else {
+    output.push_str(&format!("  pub fn new({}) -> Self {{\n", params.join(", ")));
   }
-  output.push_str(") -> Self {\n");
   let mut init_fields: Vec<String> = Vec::with_capacity(field_metas.len());
   for (i, meta) in field_metas.iter().enumerate() {
     if let Some((_, ref body_expr)) = collection_infos[i] {

--- a/plugins/rust/src/generator/gen_struct.rs
+++ b/plugins/rust/src/generator/gen_struct.rs
@@ -52,10 +52,6 @@ pub fn generate(
         .ok_or_else(|| GeneratorError::MalformedDefinition("struct field missing type".into()))?;
       let raw = f.name.as_deref().unwrap_or("unknown");
       let fname = field_name(raw);
-      // Recover the Bebop schema name for decode error context:
-      // - RAW_REJECTED fields (e.g. `self`) are suffix-mangled to `self_`; use serde rename.
-      // - Keyword fields (e.g. `type`) are prefixed with `r#`; strip the prefix.
-      // - Regular fields are unchanged.
       let schema_name = raw.to_string();
       Ok(StructFieldMeta {
         fname,

--- a/plugins/rust/src/generator/gen_struct.rs
+++ b/plugins/rust/src/generator/gen_struct.rs
@@ -56,8 +56,7 @@ pub fn generate(
       // - RAW_REJECTED fields (e.g. `self`) are suffix-mangled to `self_`; use serde rename.
       // - Keyword fields (e.g. `type`) are prefixed with `r#`; strip the prefix.
       // - Regular fields are unchanged.
-      let schema_name = serde_field_rename(raw)
-        .unwrap_or_else(|| fname.strip_prefix("r#").unwrap_or(&fname).to_string());
+      let schema_name = raw.to_string();
       Ok(StructFieldMeta {
         fname,
         schema_name,

--- a/plugins/rust/src/generator/gen_union.rs
+++ b/plugins/rust/src/generator/gen_union.rs
@@ -1,7 +1,7 @@
 use crate::error::GeneratorError;
 use crate::generated::DefinitionDescriptor;
 
-use super::naming::{fqn_to_type_name, to_snake_case, type_name};
+use super::naming::{fqn_to_type_name, type_name};
 use super::{
   emit_deprecated, emit_doc_comment, has_decorator, visibility_keyword, GeneratorOptions,
   LifetimeAnalysis, FORWARD_COMPATIBLE,
@@ -30,6 +30,8 @@ pub fn generate(
     disc: u8,
     inner_type: String,
     inner_fqn: Option<String>,
+    /// Original branch name from the Bebop schema, for decode error context.
+    schema_name: String,
   }
 
   let branch_infos: Vec<BranchInfo> = branches
@@ -50,11 +52,22 @@ pub fn generate(
       } else {
         ("Unknown".to_string(), "Unknown".to_string(), None)
       };
+      let schema_name = b
+        .name
+        .as_deref()
+        .or_else(|| {
+          b.inline_fqn
+            .as_deref()
+            .and_then(|fqn| fqn.rsplit('.').next())
+        })
+        .unwrap_or("unknown")
+        .to_string();
       BranchInfo {
         variant,
         disc,
         inner_type,
         inner_fqn,
+        schema_name,
       }
     })
     .collect();
@@ -221,11 +234,9 @@ pub fn generate(
   output.push_str("    let discriminator = reader.read_byte()?;\n");
   output.push_str("    let value = match discriminator {\n");
   for b in &branch_infos {
-    // Use snake_case variant name as field_name for error context.
-    let branch_field = to_snake_case(&b.variant);
     output.push_str(&format!(
       "      {} => result::Result::Ok(Self::{}({}::decode(reader).for_field(\"{}\", \"{}\")?)),\n",
-      b.disc, b.variant, b.inner_type, name, branch_field
+      b.disc, b.variant, b.inner_type, name, b.schema_name
     ));
   }
   if is_forward_compatible {

--- a/plugins/rust/src/generator/gen_union.rs
+++ b/plugins/rust/src/generator/gen_union.rs
@@ -1,7 +1,7 @@
 use crate::error::GeneratorError;
 use crate::generated::DefinitionDescriptor;
 
-use super::naming::{fqn_to_type_name, type_name};
+use super::naming::{fqn_to_type_name, to_snake_case, type_name};
 use super::{
   emit_deprecated, emit_doc_comment, has_decorator, visibility_keyword, GeneratorOptions,
   LifetimeAnalysis, FORWARD_COMPATIBLE,
@@ -221,8 +221,8 @@ pub fn generate(
   output.push_str("    let discriminator = reader.read_byte()?;\n");
   output.push_str("    let value = match discriminator {\n");
   for b in &branch_infos {
-    // Use lowercase variant name as field_name for error context.
-    let branch_field = b.variant.to_ascii_lowercase();
+    // Use snake_case variant name as field_name for error context.
+    let branch_field = to_snake_case(&b.variant);
     output.push_str(&format!(
       "      {} => result::Result::Ok(Self::{}({}::decode(reader).for_field(\"{}\", \"{}\")?)),\n",
       b.disc, b.variant, b.inner_type, name, branch_field

--- a/plugins/rust/src/generator/gen_union.rs
+++ b/plugins/rust/src/generator/gen_union.rs
@@ -221,9 +221,11 @@ pub fn generate(
   output.push_str("    let discriminator = reader.read_byte()?;\n");
   output.push_str("    let value = match discriminator {\n");
   for b in &branch_infos {
+    // Use lowercase variant name as field_name for error context.
+    let branch_field = b.variant.to_ascii_lowercase();
     output.push_str(&format!(
-      "      {} => result::Result::Ok(Self::{}({}::decode(reader)?)),\n",
-      b.disc, b.variant, b.inner_type
+      "      {} => result::Result::Ok(Self::{}({}::decode(reader).for_field(\"{}\", \"{}\")?)),\n",
+      b.disc, b.variant, b.inner_type, name, branch_field
     ));
   }
   if is_forward_compatible {

--- a/plugins/rust/src/generator/mod.rs
+++ b/plugins/rust/src/generator/mod.rs
@@ -613,6 +613,7 @@ impl RustGenerator {
     // types. User types are PascalCase; these are all lowercase module names.
     output.push_str("use alloc::{borrow, boxed, string, vec};\n");
     output.push_str("use bebop_runtime as bebop;\n");
+    output.push_str("use bebop_runtime::DecodeContext as _;\n");
     output.push_str("use core::convert::Into as _;\n");
     output.push_str("use core::iter::{IntoIterator as _, Iterator as _};\n");
     output.push_str("use core::{convert, default, iter, mem, ops, option, result};\n");

--- a/plugins/rust/src/generator/type_mapper.rs
+++ b/plugins/rust/src/generator/type_mapper.rs
@@ -572,6 +572,41 @@ pub fn read_expression(
   }
 }
 
+/// Generate a decode expression with `.for_field()` context applied.
+///
+/// Handles zero-copy string/byte-array fields inline and delegates everything
+/// else to [`read_expression`]. The returned expression includes the trailing
+/// `?` and evaluates to the decoded field value.
+pub fn read_field_expression(
+  td: &TypeDescriptor,
+  reader: &str,
+  analysis: &LifetimeAnalysis,
+  type_name: &str,
+  field_name: &str,
+) -> Result<String, GeneratorError> {
+  let kind = td
+    .kind
+    .ok_or_else(|| GeneratorError::MalformedType("type descriptor missing kind".into()))?;
+
+  if kind == TypeKind::String {
+    Ok(format!(
+      "borrow::Cow::Borrowed({}.read_str().for_field(\"{}\", \"{}\")?)",
+      reader, type_name, field_name
+    ))
+  } else if is_byte_array_cow_field(td) {
+    Ok(format!(
+      "bebop::BebopBytes::borrowed({}.read_byte_slice().for_field(\"{}\", \"{}\")?)",
+      reader, type_name, field_name
+    ))
+  } else {
+    let read_expr = read_expression(td, reader, analysis)?;
+    Ok(format!(
+      "{}.for_field(\"{}\", \"{}\")?",
+      read_expr, type_name, field_name
+    ))
+  }
+}
+
 /// Generate a write expression for a TypeDescriptor (Cow-aware).
 ///
 /// For Cow<str> we call `writer.write_string(&v)` (Cow derefs to &str).

--- a/plugins/rust/src/generator/type_mapper.rs
+++ b/plugins/rust/src/generator/type_mapper.rs
@@ -572,28 +572,6 @@ pub fn read_expression(
   }
 }
 
-/// Returns a direct borrowed `Cow` decode expression when applicable.
-///
-/// This is used by generators that want local statements like:
-/// `let name = Cow::Borrowed(reader.read_str()?);`
-pub fn borrowed_cow_read_expression(td: &TypeDescriptor, reader: &str) -> Option<String> {
-  match td.kind? {
-    TypeKind::String => Some(format!("borrow::Cow::Borrowed({}.read_str()?)", reader)),
-    TypeKind::Array => {
-      let elem = td.array_element.as_ref()?;
-      if elem.kind == Some(TypeKind::Byte) {
-        Some(format!(
-          "bebop::BebopBytes::borrowed({}.read_byte_slice()?)",
-          reader
-        ))
-      } else {
-        None
-      }
-    }
-    _ => None,
-  }
-}
-
 /// Generate a write expression for a TypeDescriptor (Cow-aware).
 ///
 /// For Cow<str> we call `writer.write_string(&v)` (Cow derefs to &str).


### PR DESCRIPTION
Closes #7

## Summary

`DecodeError` now reports **where** a decode failure occurred, not just what went wrong.

```
// Before:
"invalid utf-8 in string"
"unexpected eof: needed 4 bytes, 2 available"

// After:
"invalid utf-8 in Person.name"
"unexpected eof in Person.age: needed 4 bytes, 2 available"
```

## Changes

### Runtime (`runtime/src/`)
- **`error.rs`** — Added `type_name` and `field_name` fields to `UnexpectedEof` and `InvalidUtf8`. Added `DecodeError::with_context()` (enriches only when not already set — innermost context always wins). Added `DecodeContext<T>` trait with `for_field()`.
- **`reader.rs`** — All `UnexpectedEof`/`InvalidUtf8` constructions initialise `type_name: ""`, `field_name: ""`.
- **`lib.rs`** — Re-exports `DecodeContext`.

### Generator (`src/generator/`)
- **`mod.rs`** — Generated files include `use bebop_runtime::DecodeContext as _;`.
- **`gen_struct.rs`** — Struct decode wraps every field read: `reader.read_str().for_field("Person", "name")?`, etc.
- **`gen_message.rs`** — Same for message field match arms.
- **`gen_union.rs`** — Union branch decodes get `for_field("UnionType", "variant")`.
- **`type_mapper.rs`** — Removed the now-dead `borrowed_cow_read_expression` helper.

## Design notes

`with_context` uses empty-string literal matching (`type_name: ""`) rather than a guard, so it only enriches errors that haven't been annotated yet. This means the **innermost** `.for_field()` call wins — it's safe to call on nested type decodes too, and outer frames provide fallback context for free. Zero cost on the success path (`map_err` runs only on error).